### PR TITLE
Feat: DailyLook 게시판 글 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/fashionlog/controller/DailyLookController.java
+++ b/src/main/java/com/example/fashionlog/controller/DailyLookController.java
@@ -43,10 +43,23 @@ public class DailyLookController {
         return "redirect:/fashionlog/dailylook";
     }
 
-    //추가 코드
     @GetMapping("/{id}")
     public String getDailyLookPostById(@PathVariable Long id, Model model) {
         model.addAttribute("dailyLook", dailyLookService.getDailyLookPostById(id));
         return "dailylook/detail";
+    }
+
+    //추가 코드
+    @GetMapping("/{id}/edit")
+    public String getDailyLookEdit(@PathVariable Long id, Model model) {
+        model.addAttribute("dailyLook", dailyLookService.getDailyLookPostById(id));
+        return "dailylook/edit";
+    }
+
+    @PostMapping("/{id}/edit")
+    public String editDailyLookPost(@PathVariable Long id,
+        @ModelAttribute DailyLookDto dailyLookDto) {
+        dailyLookService.editDailyLookPost(id, dailyLookDto);
+        return "redirect:/fashionlog/dailylook";
     }
 }

--- a/src/main/java/com/example/fashionlog/domain/DailyLook.java
+++ b/src/main/java/com/example/fashionlog/domain/DailyLook.java
@@ -1,5 +1,7 @@
 package com.example.fashionlog.domain;
 
+import com.example.fashionlog.dto.DailyLookDto;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -40,5 +42,12 @@ public class DailyLook {
     private LocalDateTime updatedAt;
     @Column
     private LocalDateTime deletedAt;
+
+    // 추가 코드
+    public void updateDailyLook(DailyLookDto dailyLookDto) {
+        this.title = dailyLookDto.getTitle();
+        this.content = dailyLookDto.getContent();
+        this.updatedAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/com/example/fashionlog/dto/DailyLookDto.java
+++ b/src/main/java/com/example/fashionlog/dto/DailyLookDto.java
@@ -47,7 +47,7 @@ public class DailyLookDto {
             .content(dailyLookDto.getContent())
             .postStatus(dailyLookDto.getPostStatus())
             .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
+            .updatedAt(dailyLookDto.getUpdatedAt())
             .deletedAt(dailyLookDto.getDeletedAt())
             .build();
     }

--- a/src/main/java/com/example/fashionlog/service/DailyLookService.java
+++ b/src/main/java/com/example/fashionlog/service/DailyLookService.java
@@ -4,8 +4,10 @@ import com.example.fashionlog.domain.DailyLook;
 import com.example.fashionlog.dto.DailyLookDto;
 import com.example.fashionlog.repository.DailyLookCommentRepository;
 import com.example.fashionlog.repository.DailyLookRepository;
+
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 
 @Service
@@ -32,10 +34,20 @@ public class DailyLookService {
         dailyLookRepository.save(dailyLook);
     }
 
-    //추가 코드
     public DailyLookDto getDailyLookPostById(Long id) {
-        DailyLook dailyLook = dailyLookRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("게시글을 찾지 못했습니다."));
+        DailyLook dailyLook = DailyLookFindById(id);
         return DailyLookDto.convertToDto(dailyLook);
+    }
+
+    //추가 코드
+    public void editDailyLookPost(Long id, DailyLookDto dailyLookDto) {
+        DailyLook dailyLook = DailyLookFindById(id);
+        dailyLook.updateDailyLook(dailyLookDto);
+        dailyLookRepository.save(dailyLook);
+    }
+
+    private DailyLook DailyLookFindById(Long id) {
+        return dailyLookRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("게시글을 찾지 못했습니다."));
     }
 }

--- a/src/main/resources/templates/dailylook/detail.html
+++ b/src/main/resources/templates/dailylook/detail.html
@@ -8,6 +8,8 @@
 <h1>Daily Look Post</h1>
 <h1 th:text="${dailyLook.title}">Title</h1>
 <p>Content: <span th:text="${dailyLook.content}">Content</span></p>
-<a href="/fashionlog/dailylook">Back to Daily Look List</a>
+<a href="/fashionlog/dailylook">뒤로</a>
+<a th:href="@{/fashionlog/dailylook/{id}/edit(id=${dailyLook.getId()})}" class="edit-btn">수정</a>
+
 </body>
 </html>

--- a/src/main/resources/templates/dailylook/edit.html
+++ b/src/main/resources/templates/dailylook/edit.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>자유 게시글 수정</title>
+  <link rel="stylesheet" th:href="@{/css/style.css}" />
+</head>
+<body>
+<h1>글 수정</h1>
+<form th:action="@{/fashionlog/dailylook/{id}/edit(id=${dailyLook.getId()})}" method="post">
+  <div>
+    <label for="title">제목</label>
+    <input type="text" id="title" name="title" th:value="${dailyLook.getTitle()}">
+  </div>
+  <div>
+    <label for="content">내용</label>
+    <textarea id="content" name="content" th:text="${dailyLook.getContent()}"></textarea>
+  </div>
+  <button type="submit">수정하기</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/dailylook/list.html
+++ b/src/main/resources/templates/dailylook/list.html
@@ -21,7 +21,9 @@
       <a th:text="${post.title}" th:href="@{/fashionlog/dailylook/{id}(id=${post.id})}">제목</a>
     </td>
     <td>작성자</td>
-    <td th:text="${post.createdAt}">작성일</td>
+    <!-- updateAt이 null 이 아니면 updateAt 표시 -->
+    <td th:if="${post.updatedAt != null}" th:text="${post.updatedAt}">작성일</td>
+    <td th:unless="${post.updatedAt != null}" th:text="${post.createdAt}">작성일</td>
   </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## 요약
> DailyLook 게시판 글 수정 기능 구현

## 관련 이슈
> Closed #42 

## 변경 사항
> - DailyLookController 글 수정, 수정 폼 엔드포인트 추가
> - DailyLookService editDailyLookPost 메서드 구현 및 게시글을 찾는 공통로직 getDailyLookPostById 으로 분리
> - 게시글 수정을 위한 edit.html 템플릿 생성
> - DailyLook Entity에 updateDailyLook 편의 메서드
> - DailyLookDto updateAt의 초기값을 null로 주기위해 convertToEntity 로직 변경

## 기타