### PR TITLE
Feat: FreeBoard 자유 게시판 댓글 생성하기 구현

### DIFF
--- a/src/main/java/com/example/fashionlog/controller/FreeBoardController.java
+++ b/src/main/java/com/example/fashionlog/controller/FreeBoardController.java
@@ -1,5 +1,6 @@
 package com.example.fashionlog.controller;
 
+import com.example.fashionlog.dto.FreeBoardCommentDto;
 import com.example.fashionlog.dto.FreeBoardDto;
 import com.example.fashionlog.service.FreeBoardService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,5 +64,12 @@ public class FreeBoardController {
 	public String deleteFreeBoardPost(@PathVariable("id") Long id) {
 		freeBoardService.deleteFreeBoardPost(id);
 		return "redirect:/fashionlog/freeboard";
+	}
+
+	@PostMapping("/{id}/comment")
+	public String saveFreeBoardComment(@PathVariable("id") Long id,
+		@ModelAttribute FreeBoardCommentDto freeBoardCommentDto) {
+		freeBoardService.createFreeBoardComment(id, freeBoardCommentDto);
+		return "redirect:/fashionlog/freeboard/{id}";
 	}
 }

--- a/src/main/java/com/example/fashionlog/domain/FreeBoardComment.java
+++ b/src/main/java/com/example/fashionlog/domain/FreeBoardComment.java
@@ -33,7 +33,7 @@ public class FreeBoardComment {
 	private String content;
 
 	@Column(nullable = false)
-	private Boolean comment_status;
+	private Boolean commentStatus;
 
 	@Column(nullable = false)
 	private LocalDateTime createdAt;

--- a/src/main/java/com/example/fashionlog/dto/FreeBoardCommentDto.java
+++ b/src/main/java/com/example/fashionlog/dto/FreeBoardCommentDto.java
@@ -1,5 +1,6 @@
 package com.example.fashionlog.dto;
 
+import com.example.fashionlog.domain.FreeBoard;
 import com.example.fashionlog.domain.FreeBoardComment;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -28,10 +29,21 @@ public class FreeBoardCommentDto {
 			.id(freeBoardComment.getId())
 			.freeBoardId(freeBoardComment.getFreeBoard().getId())
 			.content(freeBoardComment.getContent())
-			.commentStatus(freeBoardComment.getComment_status())
+			.commentStatus(freeBoardComment.getCommentStatus())
 			.createdAt(freeBoardComment.getCreatedAt())
 			.updatedAt(freeBoardComment.getUpdatedAt())
 			.deletedAt(freeBoardComment.getDeletedAt())
+			.build();
+	}
+
+	public static FreeBoardComment convertToEntity(FreeBoard findedFreeBoard, FreeBoardCommentDto freeBoardCommentDto) {
+		return FreeBoardComment.builder()
+			.freeBoard(findedFreeBoard)
+			.content(freeBoardCommentDto.getContent())
+			.commentStatus(freeBoardCommentDto.getCommentStatus() != null ? freeBoardCommentDto.getCommentStatus() : true)
+			.createdAt(freeBoardCommentDto.getCreatedAt() != null ? freeBoardCommentDto.getCreatedAt() : LocalDateTime.now())
+			.updatedAt(freeBoardCommentDto.getUpdatedAt())
+			.deletedAt(freeBoardCommentDto.getDeletedAt())
 			.build();
 	}
 }

--- a/src/main/java/com/example/fashionlog/service/FreeBoardService.java
+++ b/src/main/java/com/example/fashionlog/service/FreeBoardService.java
@@ -1,6 +1,7 @@
 package com.example.fashionlog.service;
 
 import com.example.fashionlog.domain.FreeBoard;
+import com.example.fashionlog.domain.FreeBoardComment;
 import com.example.fashionlog.dto.FreeBoardCommentDto;
 import com.example.fashionlog.dto.FreeBoardDto;
 import com.example.fashionlog.repository.FreeBoardCommentRepository;
@@ -61,5 +62,13 @@ public class FreeBoardService {
 		return freeBoardCommentRepository.findByFreeBoardId(freeBoardId).stream()
 			.map(FreeBoardCommentDto::convertToDto)
 			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public void createFreeBoardComment(Long id, FreeBoardCommentDto freeBoardCommentDto) {
+		FreeBoard freeBoard = freeBoardRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("id: " + id + " not found"));
+		FreeBoardComment freeBoardComment = FreeBoardCommentDto.convertToEntity(freeBoard, freeBoardCommentDto);
+		freeBoardCommentRepository.save(freeBoardComment);
 	}
 }

--- a/src/main/resources/templates/freeboard/detail.html
+++ b/src/main/resources/templates/freeboard/detail.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
 <head>
+  <meta charset="UTF-8">
   <title>자유 게시글 상세보기</title>
   <link rel="stylesheet" th:href="@{/css/style.css}"/>
 </head>
 <body>
+<!-- 글 상세 보기 -->
 <h1>제목</h1>
 <div class="post-detail" th:if="${post.isPresent()}">
   <h2 th:text="${post.get().title}">Title</h2>
@@ -22,6 +24,16 @@
     </form>
   </div>
 </div>
+<!-- 댓글 작성 -->
+<h3>댓글 작성</h3>
+<form th:action="@{/fashionlog/freeboard/{id}/comment(id=${post.get().id})}" method="post">
+  <div>
+    <label for="content">내용</label>
+    <textarea id="content" name="content"></textarea>
+  </div>
+  <button type="submit">작성 완료</button>
+</form>
+<!-- 댓글 목록 -->
 <div class="post-comments">
   <table>
     <thead>


### PR DESCRIPTION
## 요약
> 자유 게시판 댓글 생성하기 구현

## 관련 이슈
> Related to #49 

## 변경 사항
> - controller: saveFreeBoardComment 추가
> - dto: convertToEntity 추가
> - service: createFreeBoardComment 추가
> - templates: detail.html에 댓글 작성 폼 추가

## 기타
> domain 변수명 commentStatus 컨벤션에 맞게 재설정
> detail 템플릿의 html에 lang="ko" 추가