### PR TITLE
Feat: InterviewBoard 게시글 수정 기능 추가

### DIFF
--- a/src/main/java/com/example/fashionlog/controller/InterviewBoardController.java
+++ b/src/main/java/com/example/fashionlog/controller/InterviewBoardController.java
@@ -46,5 +46,17 @@ public class InterviewBoardController {
 		model.addAttribute("interviewPost", interviewBoardService.getInterviewPostDetail(id));
 		return "interviewboard/detail";
 	}
+
+	@GetMapping("/{id}/edit")
+	public String editInterviewPostForm(@PathVariable Long id, Model model) {
+		model.addAttribute("interviewPost", interviewBoardService.getInterviewPostDetail(id));
+		return "interviewboard/edit";
+	}
+
+	@PostMapping("/{id}/edit")
+	public String editInterviewPost(@PathVariable Long id, @ModelAttribute InterviewBoardDto interviewBoardDto) {
+		interviewBoardService.updateInterviewPost(id, interviewBoardDto);
+		return "redirect:/fashionlog/interviewboard/{id}";
+	}
 }
 

--- a/src/main/java/com/example/fashionlog/domain/InterviewBoard.java
+++ b/src/main/java/com/example/fashionlog/domain/InterviewBoard.java
@@ -1,5 +1,6 @@
 package com.example.fashionlog.domain;
 
+import com.example.fashionlog.dto.InterviewBoardDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -43,4 +44,9 @@ public class InterviewBoard {
 	@Column
 	private LocalDateTime deletedAt;
 
+	public void updateInterviewBoard(InterviewBoardDto interviewBoardDto) {
+		this.title = interviewBoardDto.getTitle();
+		this.content = interviewBoardDto.getContent();
+		this.updatedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/example/fashionlog/service/InterviewBoardService.java
+++ b/src/main/java/com/example/fashionlog/service/InterviewBoardService.java
@@ -40,5 +40,12 @@ public class InterviewBoardService {
 			.orElseThrow(() -> new IllegalArgumentException("게시판 정보를 찾을 수 없습니다."));
 		return InterviewBoardDto.fromEntity(interviewBoard);
 	}
+
+	@Transactional
+	public void updateInterviewPost(Long id, InterviewBoardDto interviewBoardDto) {
+		InterviewBoard interviewBoard = interviewBoardRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("게시판 정보를 찾을 수 없습니다."));
+		interviewBoard.updateInterviewBoard(interviewBoardDto);
+	}
 }
 

--- a/src/main/resources/templates/interviewboard/detail.html
+++ b/src/main/resources/templates/interviewboard/detail.html
@@ -10,9 +10,15 @@
     <p class="post-meta">
         작성일: <span th:text="${interviewPost.createdAt}"></span>
     </p>
+    <p class="post-meta">
+        <span th:if="${interviewPost.updatedAt}">
+            수정일: <span th:text="${interviewPost.updatedAt}"></span>
+        </span>
+    </p>
     <div class="post-content" th:text="${interviewPost.content}"></div>
     <div class="post-actions">
         <a th:href="@{/fashionlog/interviewboard}">목록으로</a>
+        <a th:href="@{/fashionlog/interviewboard/{id}/edit(id=${interviewPost.id})}" class="edit-btn">수정</a>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/interviewboard/edit.html
+++ b/src/main/resources/templates/interviewboard/edit.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <title>인터뷰 게시글 수정</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}" />
+</head>
+<body>
+<h1>인터뷰 게시글 수정</h1>
+<form th:action="@{/fashionlog/interviewboard/{id}/edit(id=${interviewPost.id})}" method="post">
+    <div>
+        <label for="title">제목</label>
+        <input type="text" id="title" name="title" th:value="${interviewPost.title}">
+    </div>
+    <div>
+        <label for="content">내용</label>
+        <textarea id="content" name="content" th:text="${interviewPost.content}"></textarea>
+    </div>
+    <button type="submit">저장</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## 요약
> InterviewBoard 게시글 수정 기능 추가

## 관련 이슈
> closed #54 

## 변경 사항
> - detail.html 수정 버튼 및 수정일 추가
> - edit.html 게시글 수정할 수 있는 페이지 작성
> - InterviewBoardController `editInterviewPost` 추가
> - InterviewBoardService `updateInterviewPost` 추가
> - InterviewBoard `updateInterviewBoard` 추가

## 기타
> `findById`는 추후 리팩토링 작업에서 메서드화 시키도록 하겠습니다!