### PR TITLE
Feat: FreeBoard 자유 게시판 댓글 삭제하기 구현 + Soft Delete 방식으로 변경

### DIFF
--- a/src/main/java/com/example/fashionlog/controller/FreeBoardController.java
+++ b/src/main/java/com/example/fashionlog/controller/FreeBoardController.java
@@ -48,10 +48,12 @@ public class FreeBoardController {
 	@GetMapping("/{id}")
 	public String getFreeBoardById(@PathVariable("id") Long id, Model model) {
 		Optional<FreeBoardDto> freeBoardOpt = freeBoardService.getFreeBoardDtoById(id);
-		Optional<List<FreeBoardCommentDto>> freeBoardCommentOpt = freeBoardService.getCommentsByFreeBoardId(id);
+		Optional<List<FreeBoardCommentDto>> freeBoardCommentOpt = freeBoardService.getCommentsByFreeBoardId(
+			id);
 
 		FreeBoardDto freeBoardDto = freeBoardOpt.orElse(new FreeBoardDto());
-		List<FreeBoardCommentDto> freeBoardCommentDto = freeBoardCommentOpt.orElse(Collections.emptyList());
+		List<FreeBoardCommentDto> freeBoardCommentDto = freeBoardCommentOpt.orElse(
+			Collections.emptyList());
 
 		model.addAttribute("post", freeBoardDto);
 		model.addAttribute("comments", freeBoardCommentDto);
@@ -74,8 +76,9 @@ public class FreeBoardController {
 	}
 
 	@PostMapping("/{id}/delete")
-	public String deleteFreeBoardPost(@PathVariable("id") Long id) {
-		freeBoardService.deleteFreeBoardPost(id);
+	public String deleteFreeBoardPost(@PathVariable("id") Long id,
+		@ModelAttribute FreeBoardDto freeBoardDto) {
+		freeBoardService.deleteFreeBoardPost(id, freeBoardDto);
 		return "redirect:/fashionlog/freeboard";
 	}
 
@@ -91,6 +94,14 @@ public class FreeBoardController {
 		@PathVariable("commentid") Long commentId,
 		@ModelAttribute FreeBoardCommentDto freeBoardCommentDto) {
 		freeBoardService.updateFreeBoardComment(postId, commentId, freeBoardCommentDto);
+		return "redirect:/fashionlog/freeboard/{postid}";
+	}
+
+	@PostMapping("/{postid}/delete-comment/{commentid}")
+	public String deleteFreeBoardComment(@PathVariable("postid") Long postId,
+		@PathVariable("commentid") Long commentId,
+		@ModelAttribute FreeBoardCommentDto freeBoardCommentDto) {
+		freeBoardService.deleteFreeBoardComment(postId, commentId, freeBoardCommentDto);
 		return "redirect:/fashionlog/freeboard/{postid}";
 	}
 }

--- a/src/main/java/com/example/fashionlog/domain/FreeBoard.java
+++ b/src/main/java/com/example/fashionlog/domain/FreeBoard.java
@@ -47,4 +47,9 @@ public class FreeBoard {
 		this.content = freeBoardDto.getContent();
 		this.updatedAt = LocalDateTime.now();
 	}
+
+	public void deleteFreeBoard(FreeBoardDto freeBoardDto) {
+		this.postStatus = Boolean.FALSE;
+		this.deletedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/example/fashionlog/domain/FreeBoardComment.java
+++ b/src/main/java/com/example/fashionlog/domain/FreeBoardComment.java
@@ -50,4 +50,9 @@ public class FreeBoardComment {
 		this.content = freeBoardCommentDto.getContent();
 		this.updatedAt = LocalDateTime.now();
 	}
+
+	public void deleteFreeBoardComment(FreeBoardCommentDto freeBoardCommentDto, FreeBoard deletedFreeBoard) {
+		this.commentStatus = Boolean.FALSE;
+		this.deletedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/example/fashionlog/service/FreeBoardService.java
+++ b/src/main/java/com/example/fashionlog/service/FreeBoardService.java
@@ -54,15 +54,17 @@ public class FreeBoardService {
 	}
 
 	@Transactional
-	public void deleteFreeBoardPost(Long id) {
+	public void deleteFreeBoardPost(Long id, FreeBoardDto freeBoardDto) {
 		FreeBoard freeBoard = freeBoardRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("id: " + id + " not found"));
-		freeBoardRepository.delete(freeBoard);
+		freeBoard.deleteFreeBoard(freeBoardDto);
+		freeBoardRepository.save(freeBoard);
 	}
 
 	public Optional<List<FreeBoardCommentDto>> getCommentsByFreeBoardId(Long freeBoardId) {
 		List<FreeBoardCommentDto> comments = freeBoardCommentRepository.findByFreeBoardId(
 				freeBoardId).stream()
+			.filter(FreeBoardComment::getCommentStatus)
 			.map(FreeBoardCommentDto::convertToDto)
 			.collect(Collectors.toList());
 		return comments.isEmpty() ? Optional.empty() : Optional.of(comments);
@@ -86,6 +88,17 @@ public class FreeBoardService {
 			.orElseThrow(
 				() -> new IllegalArgumentException("comment id:" + commentId + " not found"));
 		freeBoardComment.updateFreeBoardComment(freeBoardCommentDto, freeBoard);
+		freeBoardCommentRepository.save(freeBoardComment);
+	}
+
+	@Transactional
+	public void deleteFreeBoardComment(Long postId, Long commentId,
+		FreeBoardCommentDto freeBoardCommentDto) {
+		FreeBoard freeBoard = freeBoardRepository.findById(postId)
+			.orElseThrow(() -> new IllegalArgumentException("id: " + postId + " not found"));
+		FreeBoardComment freeBoardComment = freeBoardCommentRepository.findById(commentId)
+			.orElseThrow(() -> new IllegalArgumentException("id: " + commentId + " not found"));
+		freeBoardComment.deleteFreeBoardComment(freeBoardCommentDto, freeBoard);
 		freeBoardCommentRepository.save(freeBoardComment);
 	}
 }

--- a/src/main/resources/templates/freeboard/detail.html
+++ b/src/main/resources/templates/freeboard/detail.html
@@ -42,6 +42,7 @@
       <th>내용</th>
       <th>작성일</th>
       <th>수정 버튼</th>
+      <th>삭제 버튼</th>
     </tr>
     </thead>
     <tbody>
@@ -50,12 +51,20 @@
       <td th:text="${comment.content}"></td>
       <td th:text="${comment.createdAt}"></td>
       <td>
-        <button type="button" th:onclick="'showEditForm(' + ${comment.id} + ')'" th:id="'edit-btn-' + ${comment.id}">Edit</button>
+        <button type="button" th:onclick="'showEditForm(' + ${comment.id} + ')'"
+                th:id="'edit-btn-' + ${comment.id}">Edit
+        </button>
+      </td>
+      <td>
+        <form th:action="@{/fashionlog/freeboard/{postId}/delete-comment/{commentId}(postId=${post.id}, commentId=${comment.id})}"
+              method="post">
+          <button type="submit">Delete</button>
+        </form>
       </td>
     </tr>
     <tr th:each="comment : ${comments}" th:attr="id=${'edit-form-' + comment.id}"
         style="display:none;">
-      <td colspan="4">
+      <td colspan="5">
         <form
             th:action="@{/fashionlog/freeboard/{postId}/edit-comment/{commentId}(postId=${post.id}, commentId=${comment.id})}"
             method="post">


### PR DESCRIPTION
## 요약
> 자유 게시판 댓글 삭제하기 구현 및 삭제 방식을 Soft Delete 방식으로 변경

## 관련 이슈
> Closed #49 

## 변경 사항
> - controller: deleteFreeBoardPost 수정, deleteFreeBoardComment 추가
> - domain: deleteFreeBoard, deleteFreeBoardComment 추가
> - service: deleteFreeBoardPost, getCommentsByFreeBoardId 수정, deleteFreeBoardComment 추가
> - templates: 댓글 삭제 버튼 추가

## 기타
> - hard delete 방식 -> soft delete 방식으로 변경하여 DB에 기록은 남지만 사용자에게 보이지 않게함.
> - 로그인 부분을 구현하고 권한 설정을 구현할 때, CUD 권한이 있는 사용자에게만 생성, 수정, 삭제 버튼이 보이게 바꿔야 함.