### PR TITLE
Feat: DailyLook 댓글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/example/fashionlog/controller/DailyLookController.java
+++ b/src/main/java/com/example/fashionlog/controller/DailyLookController.java
@@ -47,13 +47,13 @@ public class DailyLookController {
     @GetMapping("/{id}")
     public String getDailyLookPostById(
         @PathVariable("id") Long id,
-        @PathVariable(required = false) Long editCommentId,
+        Long editCommentId,
         Model model) {
         model.addAttribute("dailyLook", dailyLookService.getDailyLookPostById(id));
         model.addAttribute("dailyLookComments",
             dailyLookService.getAllDailyLookCommentByDailyLookId(id));
         model.addAttribute("dailyLookComment", new DailyLookCommentDto());
-        model.addAttribute("editCommentId", editCommentId);
+//        model.addAttribute("editCommentId", editCommentId);
         return "dailylook/detail";
     }
 
@@ -67,12 +67,12 @@ public class DailyLookController {
     public String editDailyLookPost(@PathVariable("id") Long id,
         @ModelAttribute DailyLookDto dailyLookDto) {
         dailyLookService.editDailyLookPost(id, dailyLookDto);
-        return "redirect:/fashionlog/dailylook";
+        return "redirect:/fashionlog/dailylook" + id;
     }
 
     @PostMapping("{id}/delete")
     public String deleteDailyPost(@PathVariable("id") Long id) {
-        dailyLookService.deleteDailyPost(id);
+        dailyLookService.deleteDailyLookPost(id);
         return "redirect:/fashionlog/dailylook";
     }
 
@@ -92,6 +92,16 @@ public class DailyLookController {
         @ModelAttribute("dailyLookComment") DailyLookCommentDto dailyLookCommentDto
     ) {
         dailyLookService.editDailyLookComment(postId, commentId, dailyLookCommentDto);
+
+        return "redirect:/fashionlog/dailylook/" + postId;
+    }
+
+    @PostMapping("/{postid}/delete-comment/{commentid}")
+    public String deleteDailyLookComment(
+        @PathVariable("postid") Long postId,
+        @PathVariable("commentid") Long commentId
+    ) {
+        dailyLookService.deleteDailyLookComment(commentId);
 
         return "redirect:/fashionlog/dailylook/" + postId;
     }

--- a/src/main/java/com/example/fashionlog/domain/DailyLookComment.java
+++ b/src/main/java/com/example/fashionlog/domain/DailyLookComment.java
@@ -1,7 +1,7 @@
 package com.example.fashionlog.domain;
 
 import com.example.fashionlog.dto.DailyLookCommentDto;
-import com.example.fashionlog.dto.DailyLookDto;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -51,4 +51,10 @@ public class DailyLookComment {
         this.dailyLook = dailyLook;
         this.content = dailyLookCommentDto.getContent();
         this.updatedAt = LocalDateTime.now();
-    }}
+    }
+
+    public void deleteDailyLookComment() {
+        this.commentStatus = Boolean.FALSE;
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/fashionlog/repository/DailyLookCommentRepository.java
+++ b/src/main/java/com/example/fashionlog/repository/DailyLookCommentRepository.java
@@ -10,5 +10,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface DailyLookCommentRepository extends JpaRepository<DailyLookComment, Long> {
 
-    List<DailyLookComment> findAllByDailyLookId(Long id);
+    List<DailyLookComment> findAllByDailyLookIdAndCommentStatusIsTrue(Long id);
 }

--- a/src/main/java/com/example/fashionlog/service/DailyLookService.java
+++ b/src/main/java/com/example/fashionlog/service/DailyLookService.java
@@ -48,7 +48,7 @@ public class DailyLookService {
 
     @Transactional(readOnly = true)
     public List<DailyLookCommentDto> getAllDailyLookCommentByDailyLookId(Long id) {
-        List<DailyLookComment> DailyLookComments = dailyLookCommentRepository.findAllByDailyLookId(id);
+        List<DailyLookComment> DailyLookComments = dailyLookCommentRepository.findAllByDailyLookIdAndCommentStatusIsTrue(id);
         return DailyLookComments.stream().map(DailyLookCommentDto::convertToDto).collect(Collectors.toList());
     }
 
@@ -64,14 +64,15 @@ public class DailyLookService {
     }
 
     @Transactional
-    public void deleteDailyPost(Long id) {
+    public void deleteDailyLookPost(Long id) {
         dailyLookRepository.deleteById(id);
     }
 
     @Transactional
     public void createDailyLookComment(Long id, DailyLookCommentDto dailyLookCommentDto) {
+        dailyLookCommentDto.setId(null);
         dailyLookCommentDto.setDailyLookId(id);
-        dailyLookCommentDto.setCommentStatus(true);
+        dailyLookCommentDto.setCommentStatus(Boolean.TRUE);
         dailyLookCommentDto.setCreatedAt(LocalDateTime.now());
 
         DailyLook dailyLook = DailyLookFindById(id);
@@ -84,9 +85,20 @@ public class DailyLookService {
     public void editDailyLookComment(Long postId, Long commentId,
         DailyLookCommentDto dailyLookCommentDto) {
         DailyLook dailyLook = DailyLookFindById(postId);
-        DailyLookComment dailyLookComment = dailyLookCommentRepository.findById(commentId)
-            .orElseThrow(() -> new IllegalArgumentException("댓글을 찾기 못했습니다."));
+        DailyLookComment dailyLookComment = getDailyLookComment(commentId);
         dailyLookComment.updateDailyLookComment(dailyLookCommentDto, dailyLook);
         dailyLookCommentRepository.save(dailyLookComment);
+    }
+
+    @Transactional
+    public void deleteDailyLookComment(Long commentId) {
+        DailyLookComment dailyLookComment = getDailyLookComment(commentId);
+        dailyLookComment.deleteDailyLookComment();
+        dailyLookCommentRepository.save(dailyLookComment);
+    }
+
+    private DailyLookComment getDailyLookComment(Long commentId) {
+        return dailyLookCommentRepository.findById(commentId)
+            .orElseThrow(() -> new IllegalArgumentException("댓글을 찾기 못했습니다."));
     }
 }

--- a/src/main/resources/templates/dailylook/detail.html
+++ b/src/main/resources/templates/dailylook/detail.html
@@ -55,13 +55,19 @@
       <!-- 수정 버튼 -->
       <button th:id="'edit-button-' + ${comment.id}" th:onclick="'toggleEditForm(' + ${comment.id} + ')'">수정</button>
     </td>
+    <td>
+      <!-- 삭제 버튼 -->
+      <form th:action="@{/fashionlog/dailylook/{postid}/delete-comment/{commentid}(postid=${dailyLook.id}, commentid=${comment.id})}" method="post">
+        <button type="submit">삭제</button>
+      </form>
+    </td>
   </tr>
   </tbody>
 </table>
 <!-- 댓글 작성 -->
 <form th:action="@{/fashionlog/dailylook/{id}/comment(id=${dailyLook.id})}" th:object="${dailyLookComment}" method="post">
-  <label for="comment"></label>
-  <textarea id="comment" name="comment" th:field="*{content}"></textarea>
+  <label for="content">댓글</label>
+  <textarea id="content" name="content" th:field="*{content}"></textarea>
   <button type="submit">등록</button>
 </form>
 </body>


### PR DESCRIPTION
## 요약
> DailyLook 댓글 삭제 기능 구현

## 관련 이슈
> Closed #48 

## 변경 사항
> - 소프트 딜리트 방식으로 댓글 삭제 기능 추가
> - DailyLookCommentRepository findAllByDailyLookId 메서드를 findAllByDailyLookIdAndCommentStatusIsTrue 메서드로 변경
> - DailyLookService에 deleteDailyLookComment 메서드 구현: - commentStatus를 false로 설정 - deletedAt을 현재 시간으로 설정
> - DailyLookController에 댓글 삭제 엔드포인트 추가
> - 댓글 목록 조회 시 commentStatus가 true인 댓글만 반환하도록 수정
> - HTML 템플릿에 각 댓글마다 삭제 버튼 추가
> - 삭제 후 해당 게시글 상세 페이지로 리다이렉트 처리

## 기타