### PR TITLE
Feat: InterviewBoard 댓글 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/fashionlog/controller/InterviewBoardController.java
+++ b/src/main/java/com/example/fashionlog/controller/InterviewBoardController.java
@@ -74,5 +74,12 @@ public class InterviewBoardController {
 		interviewBoardService.addComment(id, interviewBoardCommentDto);
 		return "redirect:/fashionlog/interviewboard/{id}";
 	}
+
+	@PostMapping("/{postId}/edit-comment/{commentId}")
+	public String editComment(@PathVariable("postId") Long postId, @PathVariable("commentId") Long commentId,
+		@ModelAttribute InterviewBoardCommentDto interviewBoardCommentDto) {
+		interviewBoardService.updateInterviewComment(postId, commentId, interviewBoardCommentDto);
+		return "redirect:/fashionlog/interviewboard/" + postId;
+	}
 }
 

--- a/src/main/java/com/example/fashionlog/domain/InterviewBoardComment.java
+++ b/src/main/java/com/example/fashionlog/domain/InterviewBoardComment.java
@@ -1,5 +1,6 @@
 package com.example.fashionlog.domain;
 
+import com.example.fashionlog.dto.InterviewBoardCommentDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -48,4 +49,8 @@ public class InterviewBoardComment {
 	@Column
 	private LocalDateTime deletedAt;
 
+	public void updateInterviewComment(InterviewBoardCommentDto interviewBoardCommentDto) {
+		this.content = interviewBoardCommentDto.getContent();
+		this.updatedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/example/fashionlog/service/InterviewBoardService.java
+++ b/src/main/java/com/example/fashionlog/service/InterviewBoardService.java
@@ -79,5 +79,12 @@ public class InterviewBoardService {
 			interviewBoardCommentDto, interviewBoard);
 		interviewBoardCommentRepository.save(interviewBoardComment);
 	}
+
+	@Transactional
+	public void updateInterviewComment(Long postId, Long commentId, InterviewBoardCommentDto interviewBoardCommentDto) {
+		InterviewBoardComment interviewBoardComment = interviewBoardCommentRepository.findById(commentId)
+			.orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+		interviewBoardComment.updateInterviewComment(interviewBoardCommentDto);
+	}
 }
 

--- a/src/main/resources/templates/interviewboard/detail.html
+++ b/src/main/resources/templates/interviewboard/detail.html
@@ -2,6 +2,16 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
 <head>
   <title>인터뷰 게시글 상세보기</title>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <style>
+    .edit-form {
+      display: none;
+    }
+
+    .edit-buttons {
+      display: none;
+    }
+  </style>
 </head>
 <body>
 <h1>인터뷰 게시글</h1>
@@ -35,8 +45,24 @@
     </thead>
     <tbody>
     <tr th:each="comments : ${interviewComment}">
-      <td th:text="${comments.content}"></td>
-      <td th:text="${comments.createdAt}"></td>
+      <td>
+        <span class="comment-content" th:text="${comments.content}"
+              th:data-id="${comments.id}"></span>
+        <div class="edit-form">
+          <textarea class="edit-textarea"></textarea>
+        </div>
+      </td>
+      <td>
+        <span th:if="${comments.updatedAt}" th:text="${comments.updatedAt}"></span>
+        <span th:unless="${comments.updatedAt}" th:text="${comments.createdAt}"></span>
+      </td>
+      <td>
+        <button type="button" class="edit-comment">수정</button>
+        <div class="edit-buttons">
+          <button type="button" class="save-edit">저장</button>
+          <button type="button" class="cancel-edit">취소</button>
+        </div>
+      </td>
     </tr>
     </tbody>
   </table>
@@ -50,5 +76,60 @@
     <button type="submit">작성하기</button>
   </form>
 </div>
+<!--댓글 수정 javascript-->
+<script th:inline="javascript">
+  $(document).ready(function () {
+    $('.edit-comment').click(function () {
+      var row = $(this).closest('tr');
+      var content = row.find('.comment-content');
+      var editForm = row.find('.edit-form');
+      var textarea = editForm.find('.edit-textarea');
+      var editButtons = row.find('.edit-buttons');
+
+      textarea.val(content.text());
+      content.hide();
+      editForm.show();
+      $(this).hide();
+      editButtons.show();
+    });
+
+    $('.cancel-edit').click(function () {
+      var row = $(this).closest('tr');
+      row.find('.comment-content').show();
+      row.find('.edit-form').hide();
+      row.find('.edit-comment').show();
+      row.find('.edit-buttons').hide();
+    });
+
+    $('.save-edit').click(function () {
+      var row = $(this).closest('tr');
+      var content = row.find('.comment-content');
+      var editForm = row.find('.edit-form');
+      var textarea = editForm.find('.edit-textarea');
+      var commentId = content.data('id');
+      var newContent = textarea.val();
+      var postId = [[${interviewPost.id}]];
+
+      $.ajax({
+        url: '/fashionlog/interviewboard/' + postId + '/edit-comment/' + commentId,
+        type: 'POST',
+        data: {content: newContent},
+        success: function (response) {
+          content.text(newContent).show();
+          editForm.hide();
+          row.find('.edit-comment').show();
+          row.find('.edit-buttons').hide();
+        },
+        error: function (xhr, status, error) {
+          alert('댓글 수정에 실패했습니다.');
+          editForm.hide();
+          content.show();
+          row.find('.edit-comment').show();
+          row.find('.edit-buttons').hide();
+        }
+      });
+    });
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## 요약
> InterviewBoard 댓글 수정 기능 구현

## 관련 이슈
> Related #65 

## 변경 사항
> - 각 댓글마다 수정 관련 버튼(수정, 저장, 취소) 생성
> - 수정 후 작성시간을 createdAt에서 updatedAt로 변경
> - InterviewBoardController & InterviewBoardService: 수정 관련 로직 추가

## 기타
> 일단 저두 자바스크립트 이용했는데요, 추후 리팩토링 시 통일되는 자바스크립트를 사용하면 좋을 것 같습니다!