### PR TITLE
Refactor: 게시판 Entity 코드 중복성을 줄이기 위한 Base Entity 사용

### DIFF
--- a/src/main/java/com/example/fashionlog/FashionLogApplication.java
+++ b/src/main/java/com/example/fashionlog/FashionLogApplication.java
@@ -2,12 +2,13 @@ package com.example.fashionlog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class FashionLogApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(FashionLogApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/example/fashionlog/domain/BaseEntity.java
+++ b/src/main/java/com/example/fashionlog/domain/BaseEntity.java
@@ -12,6 +12,12 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+/**
+ * 게시글 Base Entity
+ *
+ * @author Hynss
+ * @version 1.0.0
+ */
 @Getter
 @MappedSuperclass
 @SuperBuilder
@@ -20,26 +26,38 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
+	// 제목
 	@Column(nullable = false)
 	private String title;
 
+	// 내용
 	@Column(nullable = false)
 	private String content;
 
+	// 게시글이 삭제 되었는지 여부 (소프트 딜리트)
 	@Column(nullable = false)
 	private Boolean status = true;
 
+	// 게시글 생성일
 	@CreatedDate
 	@Column(nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
+	// 게시글 수정일
 	@LastModifiedDate
 	@Column
 	private LocalDateTime updatedAt;
 
+	// 게시글 삭제일
 	@Column
 	private LocalDateTime deletedAt;
 
+	/**
+	 * 더티 체킹 방식 수정 로직
+	 *
+	 * @param dto 제목과 내용을 받아 오기 위한 DTO
+	 * @param <T> T에는 게시판 클래스가 들어감
+	 */
 	public <T extends Updatable> void update(T dto) {
 		// Not Null 예외 처리
 		validateField(dto.getTitle(), "Title");
@@ -49,6 +67,9 @@ public abstract class BaseEntity {
 		this.content = dto.getContent();
 	}
 
+	/**
+	 * 소프트 딜리트를 위한 더티 체킹 방식 삭제 로직
+	 */
 	public void delete() {
 		this.status = Boolean.FALSE;
 		this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/example/fashionlog/domain/BaseEntity.java
+++ b/src/main/java/com/example/fashionlog/domain/BaseEntity.java
@@ -1,0 +1,68 @@
+package com.example.fashionlog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false)
+	private String content;
+
+	@Column(nullable = false)
+	private Boolean status = true;
+
+	@CreatedDate
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column
+	private LocalDateTime updatedAt;
+
+	@Column
+	private LocalDateTime deletedAt;
+
+	public <T extends Updatable> void update(T dto) {
+		// Not Null 예외 처리
+		validateField(dto.getTitle(), "Title");
+		validateField(dto.getContent(), "Content");
+
+		this.title = dto.getTitle();
+		this.content = dto.getContent();
+	}
+
+	public void delete() {
+		this.status = Boolean.FALSE;
+		this.deletedAt = LocalDateTime.now();
+	}
+
+	/**
+	 * Not Null 예외 처리 로직
+	 *
+	 * @param field 속성
+	 * @param fieldName 속성의 이름
+	 */
+	public static void validateField(String field, String fieldName) {
+		if (field == null || field.isEmpty()) {
+			throw new IllegalArgumentException(fieldName + " cannot be null or empty");
+		}
+	}
+}

--- a/src/main/java/com/example/fashionlog/domain/CommentBaseEntity.java
+++ b/src/main/java/com/example/fashionlog/domain/CommentBaseEntity.java
@@ -1,0 +1,63 @@
+package com.example.fashionlog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public abstract class CommentBaseEntity {
+
+	@Column(nullable = false)
+	private String content;
+
+	@Column(nullable = false)
+	private Boolean commentStatus;
+
+	@CreatedDate
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column
+	private LocalDateTime updatedAt;
+
+	@Column
+	private LocalDateTime deletedAt;
+
+	public <T extends CommentUpdatable> void updateComment(T commentDto) {
+		// Not Null 예외 처리
+		validateField(commentDto.getContent(), "Content");
+
+		this.content = commentDto.getContent();
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	public void deleteComment() {
+		this.commentStatus = Boolean.FALSE;
+		this.deletedAt = LocalDateTime.now();
+	}
+
+	/**
+	 *
+	 * @param field 속성
+	 * @param fieldName 속성의 이름
+	 */
+	public static void validateField(String field, String fieldName) {
+		if (field == null || field.isEmpty()) {
+			throw new IllegalArgumentException(fieldName + " cannot be null or empty");
+		}
+	}
+}

--- a/src/main/java/com/example/fashionlog/domain/CommentBaseEntity.java
+++ b/src/main/java/com/example/fashionlog/domain/CommentBaseEntity.java
@@ -12,6 +12,12 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+/**
+ * 댓글 Base Entity
+ *
+ * @author Hynss
+ * @version 1.0.0
+ */
 @Getter
 @MappedSuperclass
 @SuperBuilder
@@ -20,23 +26,34 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class CommentBaseEntity {
 
+	// 내용
 	@Column(nullable = false)
 	private String content;
 
+	// 댓글이 삭제 되었는지 여부 (소프트 딜리트)
 	@Column(nullable = false)
 	private Boolean commentStatus;
 
+	// 댓글 생성일
 	@CreatedDate
 	@Column(nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
+	// 댓글 수정일
 	@LastModifiedDate
 	@Column
 	private LocalDateTime updatedAt;
 
+	// 댓글 삭제일
 	@Column
 	private LocalDateTime deletedAt;
 
+	/**
+	 * 더티 체킹 방식 수정 로직
+	 *
+	 * @param commentDto 내용을 받아 오기 위한 DTO
+	 * @param <T> T에는 댓글 클래스가 들어감
+	 */
 	public <T extends CommentUpdatable> void updateComment(T commentDto) {
 		// Not Null 예외 처리
 		validateField(commentDto.getContent(), "Content");
@@ -45,13 +62,17 @@ public abstract class CommentBaseEntity {
 		this.updatedAt = LocalDateTime.now();
 	}
 
+	/**
+	 * 소프트 딜리트를 위한 더티 체킹 방식 삭제 로직
+	 */
 	public void deleteComment() {
 		this.commentStatus = Boolean.FALSE;
 		this.deletedAt = LocalDateTime.now();
 	}
 
 	/**
-	 *
+	 * Not Null 예외 처리 로직
+	 * 
 	 * @param field 속성
 	 * @param fieldName 속성의 이름
 	 */

--- a/src/main/java/com/example/fashionlog/domain/CommentUpdatable.java
+++ b/src/main/java/com/example/fashionlog/domain/CommentUpdatable.java
@@ -1,0 +1,5 @@
+package com.example.fashionlog.domain;
+
+public interface CommentUpdatable {
+	String getContent();
+}

--- a/src/main/java/com/example/fashionlog/domain/CommentUpdatable.java
+++ b/src/main/java/com/example/fashionlog/domain/CommentUpdatable.java
@@ -1,5 +1,12 @@
 package com.example.fashionlog.domain;
 
+/**
+ * 댓글 수정 관련 인터페이스
+ *
+ * @author Hynss
+ * @version 1.0.0
+ */
 public interface CommentUpdatable {
+
 	String getContent();
 }

--- a/src/main/java/com/example/fashionlog/domain/Updatable.java
+++ b/src/main/java/com/example/fashionlog/domain/Updatable.java
@@ -1,0 +1,6 @@
+package com.example.fashionlog.domain;
+
+public interface Updatable {
+	String getTitle();
+	String getContent();
+}

--- a/src/main/java/com/example/fashionlog/domain/Updatable.java
+++ b/src/main/java/com/example/fashionlog/domain/Updatable.java
@@ -1,6 +1,13 @@
 package com.example.fashionlog.domain;
 
+/**
+ * 게시글 수정 관련 인터페이스
+ *
+ * @author Hynss
+ * @version 1.0.0
+ */
 public interface Updatable {
+
 	String getTitle();
 	String getContent();
 }


### PR DESCRIPTION
## 요약
> 게시판 Entity 코드 중복성을 줄이기 위한 Base Entity 사용

## 관련 이슈
> Closed #94
> Closed #96 

## 변경 사항
> - BaseEntity, CommentBaseEntity abstract 클래스 추가.
> - Updatable, CommentUpdatable 인터페이스 추가.
> - FashionLogApplication에 @EnableJpaAuditing 추가.

## 기타
> Base Entity 관련 코드 주석 처리