### PR TITLE
Refactor: FreeBoard 세 번째 전반적인 리팩토링 및 게시글 생성 오류 수정

### DIFF
--- a/src/main/java/com/example/fashionlog/controller/FreeBoardController.java
+++ b/src/main/java/com/example/fashionlog/controller/FreeBoardController.java
@@ -6,7 +6,7 @@ import com.example.fashionlog.service.FreeBoardService;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,16 +21,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * @author Hynss
  * @version 1.0.0
  */
+@RequiredArgsConstructor
 @Controller
 @RequestMapping("/fashionlog/freeboard")
 public class FreeBoardController {
 
 	private final FreeBoardService freeBoardService;
-
-	@Autowired
-	public FreeBoardController(FreeBoardService freeBoardService) {
-		this.freeBoardService = freeBoardService;
-	}
 
 	/**
 	 * 자유 게시판 글 목록 조회
@@ -62,7 +58,7 @@ public class FreeBoardController {
 	 * @param freeBoardDto 폼에서 작성한 값들을 freeBoardDto로 받아옴.
 	 * @return 제목과 내용이 비어있는지 안 비어있는지에 따라 각각의 대상 페이지에 리다이렉트
 	 */
-	@PostMapping
+	@PostMapping("/new")
 	public String saveFreeBoardPost(@ModelAttribute FreeBoardDto freeBoardDto) {
 		// Not Null 예외 처리
 		try {

--- a/src/main/java/com/example/fashionlog/domain/FreeBoard.java
+++ b/src/main/java/com/example/fashionlog/domain/FreeBoard.java
@@ -1,16 +1,14 @@
 package com.example.fashionlog.domain;
 
-import com.example.fashionlog.dto.FreeBoardDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 /**
  * 자유 게시판 Entity
@@ -22,64 +20,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Builder
-public class FreeBoard {
+@SuperBuilder
+public class FreeBoard extends BaseEntity {
 
+	// 게시물 아이디(PK)
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "freeboard_id")
 	private Long id;
-
-	@Column(nullable = false)
-	private String title;
-
-	@Column(nullable = false)
-	private String content;
-
-	@Column(nullable = false)
-	private Boolean postStatus;
-
-	@Column(nullable = false)
-	private LocalDateTime createdAt;
-
-	@Column
-	private LocalDateTime updatedAt;
-
-	@Column
-	private LocalDateTime deletedAt;
-
-	/**
-	 * 수정 더티 체킹을 위한 메서드
-	 *
-	 * @param freeBoardDto 수정 할 값을 받아오기 위한 FreeBoardDto
-	 */
-	public void updateFreeBoard(FreeBoardDto freeBoardDto) {
-		// Not Null 예외 처리
-		validateField(freeBoardDto.getTitle(), "Title");
-		validateField(freeBoardDto.getContent(), "Content");
-
-		this.title = freeBoardDto.getTitle();
-		this.content = freeBoardDto.getContent();
-		this.updatedAt = LocalDateTime.now();
-	}
-
-	/**
-	 * 삭제 더티 체킹을 위한 메서드
-	 */
-	public void deleteFreeBoard() {
-		this.postStatus = Boolean.FALSE;
-		this.deletedAt = LocalDateTime.now();
-	}
-
-	/**
-	 * Not Null 예외 처리 로직
-	 *
-	 * @param field 속성
-	 * @param fieldName 속성의 이름
-	 */
-	public static void validateField(String field, String fieldName) {
-		if (field == null || field.isEmpty()) {
-			throw new IllegalArgumentException(fieldName + " cannot be null or empty");
-		}
-	}
 }

--- a/src/main/java/com/example/fashionlog/domain/FreeBoardComment.java
+++ b/src/main/java/com/example/fashionlog/domain/FreeBoardComment.java
@@ -1,6 +1,5 @@
 package com.example.fashionlog.domain;
 
-import com.example.fashionlog.dto.FreeBoardCommentDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,11 +8,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 /**
  * 자유 게시판 댓글 Entity
@@ -25,61 +23,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Builder
-public class FreeBoardComment {
+@SuperBuilder
+public class FreeBoardComment extends CommentBaseEntity {
 
+	// 댓글 아이디(PK)
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "freeboard_comment_id")
 	private Long id;
 
+	// 게시물 아이디(FK)
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "freeboard_id", nullable = false)
 	private FreeBoard freeBoard;
-
-	@Column(nullable = false)
-	private String content;
-
-	@Column(nullable = false)
-	private Boolean commentStatus;
-
-	@Column(nullable = false)
-	private LocalDateTime createdAt;
-
-	@Column
-	private LocalDateTime updatedAt;
-
-	@Column
-	private LocalDateTime deletedAt;
-
-	/**
-	 * 수정 더티 체킹을 위한 메서드
-	 *
-	 * @param freeBoardCommentDto 수정 할 값을 받아오기 위한 FreeBoardCommentDto
-	 */
-	public void updateFreeBoardComment(FreeBoardCommentDto freeBoardCommentDto) {
-		validateField(freeBoardCommentDto.getContent(), "Content");
-
-		this.content = freeBoardCommentDto.getContent();
-		this.updatedAt = LocalDateTime.now();
-	}
-
-	/**
-	 * 삭제 더티 체킹을 위한 메서드
-	 */
-	public void deleteFreeBoardComment() {
-		this.commentStatus = Boolean.FALSE;
-		this.deletedAt = LocalDateTime.now();
-	}
-
-	/**
-	 *
-	 * @param field 속성
-	 * @param fieldName 속성의 이름
-	 */
-	public static void validateField(String field, String fieldName) {
-		if (field == null || field.isEmpty()) {
-			throw new IllegalArgumentException(fieldName + " cannot be null or empty");
-		}
-	}
 }

--- a/src/main/java/com/example/fashionlog/dto/FreeBoardCommentDto.java
+++ b/src/main/java/com/example/fashionlog/dto/FreeBoardCommentDto.java
@@ -1,5 +1,6 @@
 package com.example.fashionlog.dto;
 
+import com.example.fashionlog.domain.CommentUpdatable;
 import com.example.fashionlog.domain.FreeBoard;
 import com.example.fashionlog.domain.FreeBoardComment;
 import java.time.LocalDateTime;
@@ -18,15 +19,21 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 @Builder
-public class FreeBoardCommentDto {
+public class FreeBoardCommentDto implements CommentUpdatable {
 
-	private Long id;
-	private Long freeBoardId;
-	private String content;
-	private Boolean commentStatus;
-	private LocalDateTime createdAt;
-	private LocalDateTime updatedAt;
-	private LocalDateTime deletedAt;
+	private Long id; // 댓글 id
+	private Long freeBoardId; // 게시물 id
+	private String content; // 내용
+	private Boolean commentStatus; // 댓글의 삭제 여부(소프트 딜리트)
+	private LocalDateTime createdAt; // 댓글 생성일
+	private LocalDateTime updatedAt; // 댓글 수정일
+	private LocalDateTime deletedAt; // 댓글 삭제일
+
+	// CommentUpdatable getContent 구현
+	@Override
+	public String getContent() {
+		return this.content;
+	}
 
 	/**
 	 * FreeBoardCommentDto -> FreeBoardComment

--- a/src/main/java/com/example/fashionlog/dto/FreeBoardDto.java
+++ b/src/main/java/com/example/fashionlog/dto/FreeBoardDto.java
@@ -1,6 +1,7 @@
 package com.example.fashionlog.dto;
 
 import com.example.fashionlog.domain.FreeBoard;
+import com.example.fashionlog.domain.Updatable;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,15 +18,27 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 @Builder
-public class FreeBoardDto {
+public class FreeBoardDto implements Updatable {
 
-	private Long id;
-	private String title;
-	private String content;
-	private Boolean postStatus;
-	private LocalDateTime createdAt;
-	private LocalDateTime updatedAt;
-	private LocalDateTime deletedAt;
+	private Long id; // 게시물 id
+	private String title; // 게시물 제목
+	private String content; // 내용
+	private Boolean status; // 게시물의 삭제 여부(소프트 딜리트)
+	private LocalDateTime createdAt; // 게시물 생성일
+	private LocalDateTime updatedAt; // 게시물 수정일
+	private LocalDateTime deletedAt; // 게시물 삭제일
+
+	// Updatable getTitle 구현
+	@Override
+	public String getTitle() {
+		return this.title;
+	}
+
+	// Updatable getContent 구현
+	@Override
+	public String getContent() {
+		return this.content;
+	}
 
 	/**
 	 * FreeBoardDto -> FreeBoard
@@ -34,7 +47,7 @@ public class FreeBoardDto {
 		return FreeBoard.builder()
 			.title(freeBoardDto.getTitle())
 			.content(freeBoardDto.getContent())
-			.postStatus(freeBoardDto.getPostStatus() != null ? freeBoardDto.getPostStatus() : true)
+			.status(freeBoardDto.getStatus() != null ? freeBoardDto.getStatus() : true)
 			.createdAt(freeBoardDto.getCreatedAt() != null ? freeBoardDto.getCreatedAt()
 				: LocalDateTime.now())
 			.updatedAt(freeBoardDto.getUpdatedAt())
@@ -50,7 +63,7 @@ public class FreeBoardDto {
 			.id(freeBoard.getId())
 			.title(freeBoard.getTitle())
 			.content(freeBoard.getContent())
-			.postStatus(freeBoard.getPostStatus())
+			.status(freeBoard.getStatus())
 			.createdAt(freeBoard.getCreatedAt())
 			.updatedAt(freeBoard.getUpdatedAt())
 			.deletedAt(freeBoard.getDeletedAt())

--- a/src/main/java/com/example/fashionlog/repository/FreeBoardRepository.java
+++ b/src/main/java/com/example/fashionlog/repository/FreeBoardRepository.java
@@ -14,8 +14,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface FreeBoardRepository extends JpaRepository<FreeBoard, Long> {
 
 	// 자유 게시판 id가 같고 삭제되지 않은 게시물들을 조회함.
-	Optional<FreeBoard> findByIdAndPostStatusIsTrue(Long id);
+	Optional<FreeBoard> findByIdAndStatusIsTrue(Long id);
 
 	// 삭제되지 않은 게시물들을 조회함.
-	List<FreeBoard> findAllByPostStatusIsTrue();
+	List<FreeBoard> findAllByStatusIsTrue();
 }

--- a/src/main/java/com/example/fashionlog/service/FreeBoardService.java
+++ b/src/main/java/com/example/fashionlog/service/FreeBoardService.java
@@ -9,7 +9,7 @@ import com.example.fashionlog.repository.FreeBoardRepository;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Hynss
  * @version 1.0.0
  */
+@RequiredArgsConstructor
 @Service
 @Transactional(readOnly = true)
 public class FreeBoardService {
@@ -26,20 +27,13 @@ public class FreeBoardService {
 	private final FreeBoardRepository freeBoardRepository;
 	private final FreeBoardCommentRepository freeBoardCommentRepository;
 
-	@Autowired
-	public FreeBoardService(FreeBoardRepository freeBoardRepository,
-		FreeBoardCommentRepository freeBoardCommentRepository) {
-		this.freeBoardRepository = freeBoardRepository;
-		this.freeBoardCommentRepository = freeBoardCommentRepository;
-	}
-
 	/**
 	 * 자유 게시판 글 목록 조회하기 API
 	 *
 	 * @return getPostStatus(글이 삭제되었는지, soft delete 방식)가 true일 경우 자유 게시판의 전체 글을 반환함.
 	 */
 	public Optional<List<FreeBoardDto>> getAllFreeBoards() {
-		List<FreeBoardDto> freeBoards = freeBoardRepository.findAllByPostStatusIsTrue().stream()
+		List<FreeBoardDto> freeBoards = freeBoardRepository.findAllByStatusIsTrue().stream()
 			.map(FreeBoardDto::convertToDto)
 			.collect(Collectors.toList());
 		return freeBoards.isEmpty() ? Optional.empty() : Optional.of(freeBoards);
@@ -66,7 +60,7 @@ public class FreeBoardService {
 	 * @return 자유 게시판 데이터베이스에서 id가 같은 게시글을 반환함.
 	 */
 	public Optional<FreeBoardDto> getFreeBoardDtoById(Long id) {
-		return freeBoardRepository.findByIdAndPostStatusIsTrue(id)
+		return freeBoardRepository.findByIdAndStatusIsTrue(id)
 			.map(FreeBoardDto::convertToDto);
 	}
 
@@ -84,7 +78,7 @@ public class FreeBoardService {
 
 		FreeBoard freeBoard = freeBoardRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("id: " + id + " not found"));
-		freeBoard.updateFreeBoard(freeBoardDto);
+		freeBoard.update(freeBoardDto);
 	}
 
 	/**
@@ -96,7 +90,7 @@ public class FreeBoardService {
 	public void deleteFreeBoardPost(Long id) {
 		FreeBoard freeBoard = freeBoardRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("id: " + id + " not found"));
-		freeBoard.deleteFreeBoard();
+		freeBoard.delete();
 	}
 
 	/**
@@ -147,7 +141,7 @@ public class FreeBoardService {
 		FreeBoardComment freeBoardComment = freeBoardCommentRepository.findById(commentId)
 			.orElseThrow(
 				() -> new IllegalArgumentException("comment id:" + commentId + " not found"));
-		freeBoardComment.updateFreeBoardComment(freeBoardCommentDto);
+		freeBoardComment.updateComment(freeBoardCommentDto);
 	}
 
 	/**
@@ -159,6 +153,6 @@ public class FreeBoardService {
 	public void deleteFreeBoardComment(Long commentId) {
 		FreeBoardComment freeBoardComment = freeBoardCommentRepository.findById(commentId)
 			.orElseThrow(() -> new IllegalArgumentException("id: " + commentId + " not found"));
-		freeBoardComment.deleteFreeBoardComment();
+		freeBoardComment.deleteComment();
 	}
 }

--- a/src/main/resources/templates/freeboard/form.html
+++ b/src/main/resources/templates/freeboard/form.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-
 <head>
   <meta charset="UTF-8">
   <title>새 글 작성</title>


### PR DESCRIPTION
## 요약
> FreeBoard 세 번째 전반적인 리팩토링 및 게시글 생성 오류 수정 후 주석 추가

## 관련 이슈
> Closed #97, Closed #98

## 변경 사항
> - domain: Base Entity 상속
> - dto: Updatable 인터페이스 구현 및 get 메서드 구현
> - Controller: `@RequiredArgsConstructor` 사용
> - Service: `@RequiredArgsConstructor` 사용, abstract에서 구현한 update, delete 메서드로 변경
> - Repository: postStatus -> status에 맞게 메서드 이름 변경

## 기타
> - `@RequiredArgsConstructor`를 이용하여 DI 주입
> - postStatus -> status로 변수명 변경, 생성 시 fashionlog/freeboard/new로 리다이렉트하게 유도