### PR TITLE
Refactor: DailyLook 게시판 엔티티에 BaseEntity 상속 및 Dto 에 Updatable 구현

### DIFF
--- a/src/main/java/com/example/fashionlog/controller/DailyLookController.java
+++ b/src/main/java/com/example/fashionlog/controller/DailyLookController.java
@@ -87,7 +87,7 @@ public class DailyLookController {
         @PathVariable("commentid") Long commentId,
         @ModelAttribute("dailyLookComment") DailyLookCommentDto dailyLookCommentDto
     ) {
-        dailyLookService.editDailyLookComment(postId, commentId, dailyLookCommentDto);
+        dailyLookService.editDailyLookComment(commentId, dailyLookCommentDto);
 
         return "redirect:/fashionlog/dailylook/" + postId;
     }

--- a/src/main/java/com/example/fashionlog/domain/DailyLook.java
+++ b/src/main/java/com/example/fashionlog/domain/DailyLook.java
@@ -1,57 +1,29 @@
 package com.example.fashionlog.domain;
 
-import com.example.fashionlog.dto.DailyLookDto;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
-import java.time.LocalDateTime;
+import jakarta.persistence.Table;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class DailyLook {
+@Table(name = "daily_look")
+public class DailyLook extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "daily_look_id")
     private Long id;
-
-    @Column(nullable = false)
-    private String title;
-
-    @Column(nullable = false)
-    private String content;
-
-    @Column(nullable = false)
-    private Boolean postStatus;
-
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-    @Column
-    private LocalDateTime updatedAt;
-    @Column
-    private LocalDateTime deletedAt;
-
-    public void updateDailyLook(DailyLookDto dailyLookDto) {
-        this.title = dailyLookDto.getTitle();
-        this.content = dailyLookDto.getContent();
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    public void deleteDailyLook() {
-        this.postStatus = Boolean.FALSE;
-        this.deletedAt = LocalDateTime.now();
-    }
 
 }

--- a/src/main/java/com/example/fashionlog/domain/DailyLookComment.java
+++ b/src/main/java/com/example/fashionlog/domain/DailyLookComment.java
@@ -1,7 +1,5 @@
 package com.example.fashionlog.domain;
 
-import com.example.fashionlog.dto.DailyLookCommentDto;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,19 +9,20 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
+import jakarta.persistence.Table;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-public class DailyLookComment {
+@Table(name = "daily_look_comment")
+public class DailyLookComment extends CommentBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,27 +33,4 @@ public class DailyLookComment {
     @JoinColumn(name = "daily_look_id")
     private DailyLook dailyLook;
 
-    @Column(nullable = false)
-    private String content;
-
-    @Column(nullable = false)
-    private Boolean commentStatus;
-
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-    @Column
-    private LocalDateTime updatedAt;
-    @Column
-    private LocalDateTime deletedAt;
-
-    public void updateDailyLookComment(DailyLookCommentDto dailyLookCommentDto, DailyLook dailyLook) {
-        this.dailyLook = dailyLook;
-        this.content = dailyLookCommentDto.getContent();
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    public void deleteDailyLookComment() {
-        this.commentStatus = Boolean.FALSE;
-        this.deletedAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/com/example/fashionlog/dto/DailyLookCommentDto.java
+++ b/src/main/java/com/example/fashionlog/dto/DailyLookCommentDto.java
@@ -1,5 +1,6 @@
 package com.example.fashionlog.dto;
 
+import com.example.fashionlog.domain.CommentUpdatable;
 import com.example.fashionlog.domain.DailyLook;
 import com.example.fashionlog.domain.DailyLookComment;
 
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class DailyLookCommentDto {
+public class DailyLookCommentDto implements CommentUpdatable {
 
     private Long id;
     private Long dailyLookId;
@@ -26,6 +27,11 @@ public class DailyLookCommentDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
+
+    @Override
+    public String getContent() {
+        return this.content;
+    }
 
     public static DailyLookCommentDto convertToDto(DailyLookComment dailyLookComment) {
 

--- a/src/main/java/com/example/fashionlog/dto/DailyLookDto.java
+++ b/src/main/java/com/example/fashionlog/dto/DailyLookDto.java
@@ -2,6 +2,7 @@ package com.example.fashionlog.dto;
 
 import com.example.fashionlog.domain.DailyLook;
 
+import com.example.fashionlog.domain.Updatable;
 import java.time.LocalDateTime;
 
 import lombok.AllArgsConstructor;
@@ -16,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class DailyLookDto {
+public class DailyLookDto implements Updatable {
 
     private Long id;
     private String title;
@@ -26,12 +27,22 @@ public class DailyLookDto {
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
 
+    @Override
+    public String getTitle() {
+        return this.title;
+    }
+
+    @Override
+    public String getContent() {
+        return this.content;
+    }
+
     public static DailyLookDto convertToDto(DailyLook dailyLook) {
         return DailyLookDto.builder()
             .id(dailyLook.getId())
             .title(dailyLook.getTitle())
             .content(dailyLook.getContent())
-            .postStatus(dailyLook.getPostStatus())
+            .postStatus(dailyLook.getStatus())
             .createdAt(dailyLook.getCreatedAt())
             .updatedAt(dailyLook.getUpdatedAt())
             .deletedAt(dailyLook.getDeletedAt())
@@ -43,7 +54,7 @@ public class DailyLookDto {
             .id(dailyLookDto.getId())
             .title(dailyLookDto.getTitle())
             .content(dailyLookDto.getContent())
-            .postStatus(dailyLookDto.getPostStatus())
+            .status(dailyLookDto.getPostStatus())
             .createdAt(LocalDateTime.now())
             .updatedAt(dailyLookDto.getUpdatedAt())
             .deletedAt(dailyLookDto.getDeletedAt())

--- a/src/main/java/com/example/fashionlog/repository/DailyLookRepository.java
+++ b/src/main/java/com/example/fashionlog/repository/DailyLookRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DailyLookRepository extends JpaRepository<DailyLook, Long> {
 
-    Optional<DailyLook> findByIdAndPostStatusIsTrue(Long id);
+    Optional<DailyLook> findByIdAndStatusIsTrue(Long id);
 
-    List<DailyLook> findAllByPostStatusIsTrue();
+    List<DailyLook> findAllByStatusIsTrue();
 }

--- a/src/main/java/com/example/fashionlog/service/DailyLookService.java
+++ b/src/main/java/com/example/fashionlog/service/DailyLookService.java
@@ -30,7 +30,7 @@ public class DailyLookService {
 
     @Transactional(readOnly = true)
     public List<DailyLookDto> getAllDailyLookPost() {
-        List<DailyLook> dailyLookList = dailyLookRepository.findAllByPostStatusIsTrue();
+        List<DailyLook> dailyLookList = dailyLookRepository.findAllByStatusIsTrue();
         return dailyLookList.stream().map(DailyLookDto::convertToDto).collect(Collectors.toList());
     }
 
@@ -57,17 +57,17 @@ public class DailyLookService {
     @Transactional
     public void editDailyLookPost(Long id, DailyLookDto dailyLookDto) {
         DailyLook dailyLook = findDailyLookById(id);
-        dailyLook.updateDailyLook(dailyLookDto);
+        dailyLook.update(dailyLookDto);
     }
 
     @Transactional
     public void deleteDailyLookPost(Long id) {
         DailyLook dailyLook = findDailyLookById(id);
-        dailyLook.deleteDailyLook();
+        dailyLook.delete();
     }
 
     private DailyLook findDailyLookById(Long id) {
-        return dailyLookRepository.findByIdAndPostStatusIsTrue(id)
+        return dailyLookRepository.findByIdAndStatusIsTrue(id)
             .orElseThrow(() -> new EntityNotFoundException("post를 찾지 못했습니다."));
     }
 
@@ -85,17 +85,16 @@ public class DailyLookService {
     }
 
     @Transactional
-    public void editDailyLookComment(Long postId, Long commentId,
+    public void editDailyLookComment(Long commentId,
         DailyLookCommentDto dailyLookCommentDto) {
-        DailyLook dailyLook = findDailyLookById(postId);
         DailyLookComment dailyLookComment = getDailyLookComment(commentId);
-        dailyLookComment.updateDailyLookComment(dailyLookCommentDto, dailyLook);
+        dailyLookComment.updateComment(dailyLookCommentDto);
     }
 
     @Transactional
     public void deleteDailyLookComment(Long commentId) {
         DailyLookComment dailyLookComment = getDailyLookComment(commentId);
-        dailyLookComment.deleteDailyLookComment();
+        dailyLookComment.deleteComment();
     }
 
     private DailyLookComment getDailyLookComment(Long commentId) {


### PR DESCRIPTION
## 요약
> DailyLook 게시판 엔티티에 BaseEntity 상속 및 Dto 에 Updatable 구현

## 관련 이슈
Closed #99 

## 변경 사항
> - domain: Base Entity 상속
> - dto: Updatable 인터페이스 구현 및 get 메서드 구현
> - Service:
>   - updateDailyLook -> update, deleteDailyLook -> delete 메서드로 변경
>   - editDailyLookComment 메서드의 매개변수 Long postId 삭제
> - Repository: postStatus -> status에 맞게 메서드 이름 변경관련된 이슈 번호

## 기타