### PR TITLE
Fix: InterviewBoard 게시글, 댓글 관련 오류 수정

### DIFF
--- a/src/main/java/com/example/fashionlog/repository/InterviewBoardCommentRepository.java
+++ b/src/main/java/com/example/fashionlog/repository/InterviewBoardCommentRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface InterviewBoardCommentRepository extends
 	JpaRepository<InterviewBoardComment, Long> {
 
-	List<InterviewBoardComment> findByInterviewBoard_Id(Long id);
+	List<InterviewBoardComment> findAllByCommentStatusIsTrueAndInterviewBoardId(Long id);
 }

--- a/src/main/java/com/example/fashionlog/service/InterviewBoardService.java
+++ b/src/main/java/com/example/fashionlog/service/InterviewBoardService.java
@@ -63,7 +63,8 @@ public class InterviewBoardService {
 	}
 
 	public List<InterviewBoardCommentDto> getCommentList(Long id) {
-		List<InterviewBoardComment> interviewBoardCommentList = interviewBoardCommentRepository.findByInterviewBoard_Id(id);
+		List<InterviewBoardComment> interviewBoardCommentList =
+			interviewBoardCommentRepository.findAllByCommentStatusIsTrueAndInterviewBoardId(id);
 		return interviewBoardCommentList.stream().map(InterviewBoardCommentDto::fromEntity)
 			.collect(Collectors.toList());
 	}
@@ -82,15 +83,18 @@ public class InterviewBoardService {
 	}
 
 	@Transactional
-	public void updateInterviewComment(Long postId, Long commentId, InterviewBoardCommentDto interviewBoardCommentDto) {
-		InterviewBoardComment interviewBoardComment = interviewBoardCommentRepository.findById(commentId)
+	public void updateInterviewComment(Long postId, Long commentId,
+		InterviewBoardCommentDto interviewBoardCommentDto) {
+		InterviewBoardComment interviewBoardComment = interviewBoardCommentRepository.findById(
+				commentId)
 			.orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
 		interviewBoardComment.updateComment(interviewBoardCommentDto);
 	}
 
 	@Transactional
 	public void deleteInterviewBoardComment(Long commentId) {
-		InterviewBoardComment interviewBoardComment = interviewBoardCommentRepository.findById(commentId)
+		InterviewBoardComment interviewBoardComment = interviewBoardCommentRepository.findById(
+				commentId)
 			.orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
 		interviewBoardComment.deleteComment();
 	}

--- a/src/main/resources/templates/interviewboard/detail.html
+++ b/src/main/resources/templates/interviewboard/detail.html
@@ -71,7 +71,7 @@
     </ul>
     <!-- 댓글 작성 -->
     <form class="comment-form" th:action="@{/fashionlog/interviewboard/{id}/comment(id=${interviewPost.id})}" th:object="${interviewPost}" method="post">
-      <textarea id="content" name="content" th:field="*{content}" placeholder="댓글을 입력하세요"></textarea>
+      <textarea id="content" name="content" placeholder="댓글을 입력하세요"></textarea>
       <button type="submit">등록</button>
     </form>
   </div>

--- a/src/main/resources/templates/interviewboard/form.html
+++ b/src/main/resources/templates/interviewboard/form.html
@@ -33,11 +33,11 @@
             <label for="content">Content</label>
             <textarea id="content" name="content" th:field="*{content}" required></textarea>
         </div>
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">등록</button>
+            <a th:href="@{/fashionlog/interviewboard}" class="btn btn-secondary">취소</a>
+        </div>
     </form>
-    <div class="form-actions">
-        <button type="submit" class="btn btn-primary">등록</button>
-        <a th:href="@{/fashionlog/interviewboard}" class="btn btn-secondary">취소</a>
-    </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## 요약
> InterviewBoard 게시글, 댓글 관련 오류 수정

## 관련 이슈
> closed #118 

## 변경 사항
> - 새 글을 등록할 수 있도록 button 태그를 위치 변경
> - 댓글 입력창에 내용이 입력되는 부분 수정
> - 삭제되지 않은 `status = true` 인 댓글만 보여지도록 수정

## 기타
>