### PR TITLE
Feat: 회원 탈퇴 기능추가

### DIFF
--- a/src/main/java/com/example/fashionlog/controller/FreeBoardController.java
+++ b/src/main/java/com/example/fashionlog/controller/FreeBoardController.java
@@ -147,10 +147,9 @@ public class FreeBoardController {
 	 * @return 자유 게시판 글 목록 페이지로 리다이렉트
 	 */
 	@PostMapping("/{id}/delete")
-	public String deleteFreeBoardPost(@PathVariable("id") Long id,
-		@ModelAttribute FreeBoardDto freeBoardDto) {
+	public String deleteFreeBoardPost(@PathVariable("id") Long id) {
 		try {
-			freeBoardService.deleteFreeBoardPost(id, freeBoardDto);
+			freeBoardService.deleteFreeBoardPost(id);
 			return "redirect:/fashionlog/freeboard";
 		} catch (SecurityException e) {
 			return "redirect:/fashionlog/freeboard/{id}";
@@ -210,10 +209,9 @@ public class FreeBoardController {
 	 */
 	@PostMapping("/{postid}/delete-comment/{commentid}")
 	public String deleteFreeBoardComment(@PathVariable("postid") Long postId,
-		@PathVariable("commentid") Long commentId,
-		@ModelAttribute FreeBoardCommentDto freeBoardCommentDto) {
+		@PathVariable("commentid") Long commentId) {
 		try {
-			freeBoardService.deleteFreeBoardComment(commentId, freeBoardCommentDto);
+			freeBoardService.deleteFreeBoardComment(commentId);
 			return "redirect:/fashionlog/freeboard/" + postId;
 		} catch (SecurityException e) {
 			return "redirect:/fashionlog/freeboard/" + postId;

--- a/src/main/java/com/example/fashionlog/controller/user/WithdrawalController.java
+++ b/src/main/java/com/example/fashionlog/controller/user/WithdrawalController.java
@@ -1,0 +1,22 @@
+package com.example.fashionlog.controller.user;
+
+import com.example.fashionlog.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/fashionlog")
+public class WithdrawalController {
+	private final MemberService memberService;
+
+	@PostMapping("/withdrawal")
+	public String withdrawal(HttpServletRequest request, HttpServletResponse response) {
+		memberService.withdrawMember(request, response);
+		return "redirect:/";
+	}
+}

--- a/src/main/java/com/example/fashionlog/domain/Member.java
+++ b/src/main/java/com/example/fashionlog/domain/Member.java
@@ -1,5 +1,6 @@
 package com.example.fashionlog.domain;
 
+import com.example.fashionlog.dto.MemberDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -8,9 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-
 import java.time.LocalDateTime;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,6 +44,9 @@ public class Member {
 	private String password;
 
 	@Column(nullable = false)
+	private Boolean status;
+
+	@Column(nullable = false)
 	private LocalDateTime createdAt;
 
 	@Column
@@ -56,4 +58,22 @@ public class Member {
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private Role role;
+
+	/**
+	 * 더티 체킹 방식 수정 로직
+	 *
+	 * @param memberDto 받아올 회원 DTO
+	 */
+	public void updateRole(MemberDto memberDto, Role role) {
+		this.role = role;
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	/**
+	 * 소프트 딜리트를 위한 더티 체킹 방식 삭제 로직
+	 */
+	public void deleteMember() {
+		this.status = Boolean.FALSE;
+		this.deletedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/example/fashionlog/dto/FreeBoardCommentDto.java
+++ b/src/main/java/com/example/fashionlog/dto/FreeBoardCommentDto.java
@@ -3,6 +3,7 @@ package com.example.fashionlog.dto;
 import com.example.fashionlog.domain.CommentUpdatable;
 import com.example.fashionlog.domain.FreeBoard;
 import com.example.fashionlog.domain.FreeBoardComment;
+import com.example.fashionlog.domain.Member;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -40,10 +41,10 @@ public class FreeBoardCommentDto implements CommentUpdatable {
 	 * FreeBoardCommentDto -> FreeBoardComment
 	 */
 	public static FreeBoardComment convertToEntity(FreeBoard findedFreeBoard,
-		FreeBoardCommentDto freeBoardCommentDto) {
+		FreeBoardCommentDto freeBoardCommentDto, Member member) {
 		return FreeBoardComment.builder()
+			.member(member)
 			.freeBoard(findedFreeBoard)
-			.memberId(freeBoardCommentDto.getMemberId())
 			.content(freeBoardCommentDto.getContent())
 			.commentStatus(freeBoardCommentDto.getCommentStatus() != null
 				? freeBoardCommentDto.getCommentStatus() : true)
@@ -61,8 +62,8 @@ public class FreeBoardCommentDto implements CommentUpdatable {
 	public static FreeBoardCommentDto convertToDto(FreeBoardComment freeBoardComment) {
 		return FreeBoardCommentDto.builder()
 			.id(freeBoardComment.getId())
+			.memberId(freeBoardComment.getMember().getMemberId())
 			.freeBoardId(freeBoardComment.getFreeBoard().getId())
-			.memberId(freeBoardComment.getMemberId())
 			.content(freeBoardComment.getContent())
 			.commentStatus(freeBoardComment.getCommentStatus())
 			.createdAt(freeBoardComment.getCreatedAt())

--- a/src/main/java/com/example/fashionlog/dto/FreeBoardDto.java
+++ b/src/main/java/com/example/fashionlog/dto/FreeBoardDto.java
@@ -1,6 +1,7 @@
 package com.example.fashionlog.dto;
 
 import com.example.fashionlog.domain.FreeBoard;
+import com.example.fashionlog.domain.Member;
 import com.example.fashionlog.domain.Updatable;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -44,9 +45,9 @@ public class FreeBoardDto implements Updatable {
 	/**
 	 * FreeBoardDto -> FreeBoard
 	 */
-	public static FreeBoard convertToEntity(FreeBoardDto freeBoardDto) {
+	public static FreeBoard convertToEntity(FreeBoardDto freeBoardDto, Member member) {
 		return FreeBoard.builder()
-			.memberId(freeBoardDto.getMemberId())
+			.member(member)
 			.title(freeBoardDto.getTitle())
 			.content(freeBoardDto.getContent())
 			.status(freeBoardDto.getStatus() != null ? freeBoardDto.getStatus() : true)
@@ -63,7 +64,7 @@ public class FreeBoardDto implements Updatable {
 	public static FreeBoardDto convertToDto(FreeBoard freeBoard) {
 		return FreeBoardDto.builder()
 			.id(freeBoard.getId())
-			.memberId(freeBoard.getMemberId())
+			.memberId(freeBoard.getMember().getMemberId())
 			.title(freeBoard.getTitle())
 			.content(freeBoard.getContent())
 			.status(freeBoard.getStatus())

--- a/src/main/java/com/example/fashionlog/dto/MemberDto.java
+++ b/src/main/java/com/example/fashionlog/dto/MemberDto.java
@@ -2,9 +2,7 @@ package com.example.fashionlog.dto;
 
 import com.example.fashionlog.domain.Member;
 import com.example.fashionlog.domain.Role;
-
 import java.time.LocalDateTime;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -25,6 +23,7 @@ public class MemberDto {
     String phone;
     String email;
     String password;
+    Boolean status;
     LocalDateTime createdAt;
     LocalDateTime updatedAt;
     LocalDateTime deletedAt;
@@ -41,6 +40,7 @@ public class MemberDto {
             .phone(memberDto.getPhone())
             .email(memberDto.getEmail())
             .password(memberDto.getPassword())
+            .status(memberDto.getStatus())
             .createdAt(LocalDateTime.now())
             .updatedAt(memberDto.getUpdatedAt())
             .deletedAt(memberDto.getDeletedAt())
@@ -59,6 +59,7 @@ public class MemberDto {
             .phone(member.getPhone())
             .email(member.getEmail())
             .password(member.getPassword())
+            .status(member.getStatus())
             .createdAt(member.getCreatedAt())
             .updatedAt(member.getUpdatedAt())
             .deletedAt(member.getDeletedAt())

--- a/src/main/java/com/example/fashionlog/repository/MemberRepository.java
+++ b/src/main/java/com/example/fashionlog/repository/MemberRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Member findByEmail(String username);
+    Member findByEmailAndStatusIsTrue(String username);
 }

--- a/src/main/java/com/example/fashionlog/service/CurrentUserProvider.java
+++ b/src/main/java/com/example/fashionlog/service/CurrentUserProvider.java
@@ -31,7 +31,7 @@ public class CurrentUserProvider {
     @Transactional(readOnly = true)
     public Member getCurrentUser() {
         String currentUserEmail = SecurityUtil.getCurrentUserEmail();
-        return memberRepository.findByEmail(currentUserEmail);
+        return memberRepository.findByEmailAndStatusIsTrue(currentUserEmail);
     }
 
 }

--- a/src/main/java/com/example/fashionlog/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/fashionlog/service/CustomUserDetailsService.java
@@ -11,40 +11,41 @@ import org.springframework.stereotype.Service;
 
 /**
  * 사용자 인증을 위한 커스텀 UserDetailsService 구현
- *
- * 이 서비스는 Spring Security의 인증 프로세스에서 사용자 정보를 로드하는 역할을 담당합니다.
- * UserDetailsService 인터페이스를 구현함으로써, Spring Security가 인증 과정에서
- * 이 서비스를 사용하여 사용자 정보를 조회하고 검증할 수 있게 됩니다.
+ * <p>
+ * 이 서비스는 Spring Security의 인증 프로세스에서 사용자 정보를 로드하는 역할을 담당합니다. UserDetailsService 인터페이스를 구현함으로써,
+ * Spring Security가 인증 과정에서 이 서비스를 사용하여 사용자 정보를 조회하고 검증할 수 있게 됩니다.
  */
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final MemberRepository memberRepository;
+	private final MemberRepository memberRepository;
 
-    public CustomUserDetailsService(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
-    }
+	public CustomUserDetailsService(MemberRepository memberRepository) {
+		this.memberRepository = memberRepository;
+	}
 
-    /**
-     * 사용자명(이메일)으로 사용자 정보를 로드하는 메서드
-     *
-     * 이 메서드는 Spring Security의 인증 과정에서 자동으로 호출됩니다.
-     * 사용자가 로그인을 시도할 때, 입력한 사용자명(이메일)을 기반으로
-     * 데이터베이스에서 사용자 정보를 조회하고, 이를 Spring Security가
-     * 이해할 수 있는 UserDetails 객체로 변환합니다.
-     *
-     * @param username 사용자명 (이 애플리케이션에서는 이메일을 사용)
-     * @return UserDetails 사용자 상세 정보
-     * @throws UsernameNotFoundException 사용자를 찾을 수 없을 경우 발생
-     */
-    @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByEmail(username);
+	/**
+	 * 사용자명(이메일)으로 사용자 정보를 로드하는 메서드
+	 * <p>
+	 * 이 메서드는 Spring Security의 인증 과정에서 자동으로 호출됩니다. 사용자가 로그인을 시도할 때, 입력한 사용자명(이메일)을 기반으로 데이터베이스에서 사용자
+	 * 정보를 조회하고, 이를 Spring Security가 이해할 수 있는 UserDetails 객체로 변환합니다.
+	 *
+	 * @param username 사용자명 (이 애플리케이션에서는 이메일을 사용)
+	 * @return UserDetails 사용자 상세 정보
+	 * @throws UsernameNotFoundException 사용자를 찾을 수 없을 경우 발생
+	 */
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		Member member = memberRepository.findByEmailAndStatusIsTrue(username);
 
-        return User.builder()
-            .username(member.getEmail())
-            .password(member.getPassword())
-            .roles(member.getRole().name())
-            .build();
-    }
+		if (member == null || !member.getStatus()) {
+			throw new UsernameNotFoundException("삭제된 유저입니다.");
+		} else {
+			return User.builder()
+				.username(member.getEmail())
+				.password(member.getPassword())
+				.roles(member.getRole().name())
+				.build();
+		}
+	}
 }

--- a/src/main/java/com/example/fashionlog/service/FreeBoardService.java
+++ b/src/main/java/com/example/fashionlog/service/FreeBoardService.java
@@ -1,6 +1,7 @@
 package com.example.fashionlog.service;
 
 import com.example.fashionlog.aop.AuthCheck;
+import com.example.fashionlog.aop.AuthorType;
 import com.example.fashionlog.domain.FreeBoard;
 import com.example.fashionlog.domain.FreeBoardComment;
 import com.example.fashionlog.domain.Member;
@@ -8,13 +9,10 @@ import com.example.fashionlog.dto.FreeBoardCommentDto;
 import com.example.fashionlog.dto.FreeBoardDto;
 import com.example.fashionlog.repository.FreeBoardCommentRepository;
 import com.example.fashionlog.repository.FreeBoardRepository;
-import com.example.fashionlog.repository.MemberRepository;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,18 +25,18 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 @Transactional(readOnly = true)
-public class FreeBoardService {
+public class FreeBoardService implements BoardService {
 
 	private final FreeBoardRepository freeBoardRepository;
 	private final FreeBoardCommentRepository freeBoardCommentRepository;
-	private final MemberRepository memberRepository;
+	private final CurrentUserProvider currentUserProvider;
 
 	/**
 	 * 자유 게시판 글 목록 조회하기 API
 	 *
 	 * @return getPostStatus(글이 삭제되었는지, soft delete 방식)가 true일 경우 자유 게시판의 전체 글을 반환함.
 	 */
-	@AuthCheck({"ADMIN", "NORMAL"})
+	@AuthCheck(value = {"NORMAL", "ADMIN"}, Type = "FreeBoard", AUTHOR_TYPE = AuthorType.POST)
 	public Optional<List<FreeBoardDto>> getAllFreeBoards() {
 		List<FreeBoardDto> freeBoards = freeBoardRepository.findAllByStatusIsTrue().stream()
 			.map(FreeBoardDto::convertToDto)
@@ -51,20 +49,17 @@ public class FreeBoardService {
 	 *
 	 * @param freeBoardDto 컨트롤러에서 DB에 삽입할 DTO를 받아옴.
 	 */
-	@AuthCheck({"ADMIN", "NORMAL"})
+	@AuthCheck(value = {"NORMAL", "ADMIN"}, Type = "FreeBoard", AUTHOR_TYPE = AuthorType.POST)
 	@Transactional
 	public void createFreeBoardPost(FreeBoardDto freeBoardDto) {
 		// Not Null 예외 처리
 		FreeBoard.validateField(freeBoardDto.getTitle(), "Title");
 		FreeBoard.validateField(freeBoardDto.getContent(), "Content");
 
-		// 현재 회원 정보 가져오기
-		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-		Member currentUser = memberRepository.findByEmail(auth.getName());
+		// 현재 로그인된 사용자를 가져옵니다
+		Member currentUser = currentUserProvider.getCurrentUser();
 
-		freeBoardDto.setMemberId(currentUser.getMemberId());
-
-		freeBoardRepository.save(FreeBoardDto.convertToEntity(freeBoardDto));
+		freeBoardRepository.save(FreeBoardDto.convertToEntity(freeBoardDto, currentUser));
 	}
 
 	/**
@@ -73,7 +68,7 @@ public class FreeBoardService {
 	 * @param id 글 하나를 상세하게 보기위해 게시글 id를 받아옴.
 	 * @return 자유 게시판 데이터베이스에서 id가 같은 게시글을 반환함.
 	 */
-	@AuthCheck({"ADMIN", "NORMAL"})
+	@AuthCheck(value = {"NORMAL", "ADMIN"}, Type = "FreeBoard", AUTHOR_TYPE = AuthorType.POST)
 	public Optional<FreeBoardDto> getFreeBoardDtoById(Long id) {
 		return freeBoardRepository.findByIdAndStatusIsTrue(id)
 			.map(FreeBoardDto::convertToDto);
@@ -85,29 +80,16 @@ public class FreeBoardService {
 	 * @param id           수정할 글의 id를 받아옴.
 	 * @param freeBoardDto 컨트롤러에서 DB에 수정할 DTO를 받아옴.
 	 */
-	@AuthCheck({"ADMIN", "NORMAL"})
+	@AuthCheck(value = {"NORMAL", "ADMIN"}, Type = "FreeBoard", AUTHOR_TYPE = AuthorType.POST)
 	@Transactional
 	public void updateFreeBoardPost(Long id, FreeBoardDto freeBoardDto) {
 		// Not Null 예외 처리
 		FreeBoard.validateField(freeBoardDto.getTitle(), "Title");
 		FreeBoard.validateField(freeBoardDto.getContent(), "Content");
 
-		// 현재 회원 정보 가져오기
-		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-		Member currentUser = memberRepository.findByEmail(auth.getName());
-
 		FreeBoard freeBoard = freeBoardRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("id: " + id + " not found"));
-
-		// 현재 회원 id가 글쓴이 id와 같거나 관리자인지 확인
-		if (currentUser.getMemberId().equals(freeBoard.getMemberId())) {
-			freeBoard.update(freeBoardDto);
-		} else if (auth.getAuthorities().stream()
-			.anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN"))) {
-			freeBoard.update(freeBoardDto);
-		} else {
-			throw new SecurityException("권한이 없습니다.");
-		}
+		freeBoard.update(freeBoardDto);
 	}
 
 	/**
@@ -115,25 +97,12 @@ public class FreeBoardService {
 	 *
 	 * @param id 삭제할 글의 id를 받아옴.
 	 */
-	@AuthCheck({"ADMIN", "NORMAL"})
+	@AuthCheck(value = {"NORMAL", "ADMIN"}, Type = "FreeBoard", AUTHOR_TYPE = AuthorType.POST)
 	@Transactional
-	public void deleteFreeBoardPost(Long id, FreeBoardDto freeBoardDto) {
-		// 현재 회원 정보 가져오기
-		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-		Member currentUser = memberRepository.findByEmail(auth.getName());
-
+	public void deleteFreeBoardPost(Long id) {
 		FreeBoard freeBoard = freeBoardRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("id: " + id + " not found"));
-
-		// 현재 회원 id가 글쓴이 id와 같거나 관리자인지 확인
-		if (currentUser.getMemberId().equals(freeBoard.getMemberId())) {
-			freeBoard.delete();
-		} else if (auth.getAuthorities().stream()
-			.anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN"))) {
-			freeBoard.delete();
-		} else {
-			throw new SecurityException("권한이 없습니다.");
-		}
+		freeBoard.delete();
 	}
 
 	/**
@@ -142,7 +111,7 @@ public class FreeBoardService {
 	 * @param freeBoardId 댓글 들이 속한 자유 게시판 글의 id를 받아옴.
 	 * @return 자유 게시판에서 조회한 글에 해당하는 댓글 목록을 반환함.
 	 */
-	@AuthCheck({"ADMIN", "NORMAL"})
+	@AuthCheck(value = {"NORMAL", "ADMIN"}, Type = "FreeBoard", AUTHOR_TYPE = AuthorType.POST)
 	public Optional<List<FreeBoardCommentDto>> getCommentsByFreeBoardId(Long freeBoardId) {
 		List<FreeBoardCommentDto> comments = freeBoardCommentRepository
 			.findAllByFreeBoardIdAndCommentStatusIsTrue(freeBoardId).stream()
@@ -158,22 +127,18 @@ public class FreeBoardService {
 	 * @param id                  자유 게시판 글의 id를 컨트롤러에서 받아옴.
 	 * @param freeBoardCommentDto 컨트롤러에서 DB에 삽입할 댓글 DTO를 받아옴.
 	 */
-	@AuthCheck({"ADMIN", "NORMAL"})
+	@AuthCheck(value = {"NORMAL", "ADMIN"}, Type = "FreeBoard", AUTHOR_TYPE = AuthorType.POST)
 	@Transactional
 	public void createFreeBoardComment(Long id, FreeBoardCommentDto freeBoardCommentDto) {
 		// Not Null 예외 처리
 		FreeBoardComment.validateField(freeBoardCommentDto.getContent(), "Content");
 
-		// 현재 회원 정보 가져오기
-		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-		Member currentUser = memberRepository.findByEmail(auth.getName());
-
-		freeBoardCommentDto.setMemberId(currentUser.getMemberId());
-
 		FreeBoard freeBoard = freeBoardRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("id: " + id + " not found"));
+		Member currentUser = currentUserProvider.getCurrentUser();
+
 		FreeBoardComment freeBoardComment = FreeBoardCommentDto.convertToEntity(freeBoard,
-			freeBoardCommentDto);
+			freeBoardCommentDto, currentUser);
 		freeBoardCommentRepository.save(freeBoardComment);
 	}
 
@@ -183,30 +148,18 @@ public class FreeBoardService {
 	 * @param commentId           자유 게시판 글의 댓글 id를 컨트롤러에서 받아옴.
 	 * @param freeBoardCommentDto 컨트롤러에서 DB에 수정할 댓글 DTO를 받아옴.
 	 */
-	@AuthCheck({"ADMIN", "NORMAL"})
+	@AuthCheck(value = {"NORMAL", "ADMIN"}, Type = "FreeBoard", AUTHOR_TYPE = AuthorType.POST)
 	@Transactional
 	public void updateFreeBoardComment(Long commentId,
 		FreeBoardCommentDto freeBoardCommentDto) {
 		// Not Null 예외 처리
 		FreeBoardComment.validateField(freeBoardCommentDto.getContent(), "Content");
 
-		// 현재 회원 정보 가져오기
-		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-		Member currentUser = memberRepository.findByEmail(auth.getName());
-
 		FreeBoardComment freeBoardComment = freeBoardCommentRepository.findById(commentId)
 			.orElseThrow(
 				() -> new IllegalArgumentException("comment id:" + commentId + " not found"));
 
-		// 현재 회원 id가 글쓴이 id와 같거나 관리자인지 확인
-		if (currentUser.getMemberId().equals(freeBoardComment.getMemberId())) {
-			freeBoardComment.updateComment(freeBoardCommentDto);
-		} else if (auth.getAuthorities().stream()
-			.anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN"))) {
-			freeBoardComment.updateComment(freeBoardCommentDto);
-		} else {
-			throw new SecurityException("권한이 없습니다.");
-		}
+		freeBoardComment.updateComment(freeBoardCommentDto);
 	}
 
 	/**
@@ -214,24 +167,39 @@ public class FreeBoardService {
 	 *
 	 * @param commentId 자유 게시판 글의 댓글 id를 컨트롤러에서 받아옴.
 	 */
-	@AuthCheck({"ADMIN", "NORMAL"})
+	@AuthCheck(value = {"NORMAL", "ADMIN"}, Type = "FreeBoard", AUTHOR_TYPE = AuthorType.POST)
 	@Transactional
-	public void deleteFreeBoardComment(Long commentId, FreeBoardCommentDto freeBoardCommentDto) {
-		// 현재 회원 정보 가져오기
-		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-		Member currentUser = memberRepository.findByEmail(auth.getName());
-
+	public void deleteFreeBoardComment(Long commentId) {
 		FreeBoardComment freeBoardComment = freeBoardCommentRepository.findById(commentId)
 			.orElseThrow(() -> new IllegalArgumentException("id: " + commentId + " not found"));
+		freeBoardComment.deleteComment();
+	}
 
-		// 현재 회원 id가 글쓴이 id와 같거나 관리자인지 확인
-		if (currentUser.getMemberId().equals(freeBoardComment.getMemberId())) {
-			freeBoardComment.deleteComment();
-		} else if (auth.getAuthorities().stream()
-			.anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_ADMIN"))) {
-			freeBoardComment.deleteComment();
-		} else {
-			throw new SecurityException("권한이 없습니다.");
-		}
+	/**
+	 * 주어진 게시글 ID의 작성자가 현재 사용자인지 확인합니다.
+	 *
+	 * @param postId      확인할 게시글 ID
+	 * @param memberEmail 현재 사용자의 이메일
+	 * @return 현재 사용자가 게시글의 작성자인 경우 true, 그렇지 않은 경우 false
+	 */
+	@Override
+	public boolean isPostAuthor(Long postId, String memberEmail) {
+		return freeBoardRepository.findById(postId)
+			.map(dailyLook -> dailyLook.isAuthor(memberEmail))
+			.orElse(false);
+	}
+
+	/**
+	 * 주어진 댓글 ID의 작성자가 현재 사용자인지 확인합니다.
+	 *
+	 * @param commentId   확인할 게시글 ID
+	 * @param memberEmail 현재 사용자의 이메일
+	 * @return 현재 사용자가 게시글의 작성자인 경우 true, 그렇지 않은 경우 false
+	 */
+	@Override
+	public boolean isCommentAuthor(Long commentId, String memberEmail) {
+		return freeBoardCommentRepository.findById(commentId)
+			.map(dailyLook -> dailyLook.isAuthor(memberEmail))
+			.orElse(false);
 	}
 }

--- a/src/main/java/com/example/fashionlog/service/MemberService.java
+++ b/src/main/java/com/example/fashionlog/service/MemberService.java
@@ -4,25 +4,38 @@ import com.example.fashionlog.domain.Member;
 import com.example.fashionlog.domain.Role;
 import com.example.fashionlog.dto.MemberDto;
 import com.example.fashionlog.repository.MemberRepository;
-
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
-
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Member 서비스
+ *
+ * @author Hynss
+ * @version 1.0.0
+ */
 @Service
+@RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-
-    public MemberService(MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
-        this.memberRepository = memberRepository;
-        this.passwordEncoder = passwordEncoder;
-    }
-
+    /**
+     * 회원 가입
+     *
+     * @param memberDto 컨트롤러에서 회원 정보를 DTO로 받아옴.
+     */
+    @Transactional
     public void createMember(MemberDto memberDto) {
+        memberDto.setStatus(Boolean.TRUE);
         memberDto.setRole(Role.NORMAL);
         memberDto.setCreatedAt(LocalDateTime.now());
 
@@ -34,8 +47,25 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    // 비밀번호 변환로직
+    /**
+     * 비밀번호 변환로직
+     */
     private String getEncodedPassword(MemberDto memberDto) {
         return passwordEncoder.encode(memberDto.getPassword());
+    }
+
+    /**
+     * 회원 탈퇴
+     */
+    @Transactional
+    public void withdrawMember(HttpServletRequest request, HttpServletResponse response) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Member currentUser = memberRepository.findByEmailAndStatusIsTrue(auth.getName());
+        if (currentUser != null) {
+            currentUser.deleteMember();
+
+            // 로그아웃 처리
+            new SecurityContextLogoutHandler().logout(request, response, auth);
+        }
     }
 }

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -19,7 +19,9 @@
         <button class="login">UserName</button>
       </li>
       <li>
-        <button class="signup">탈퇴</button>
+        <form th:action="@{/fashionlog/withdrawal}" method="post">
+          <input type="submit" value="회원 탈퇴">
+        </form>
       </li>
     </ul>
     <form th:action="@{/logout}" method="post">


### PR DESCRIPTION
## 요약
> - 회원 탈퇴 기능 추가
> - 자유 게시판 리팩토링

## 관련 이슈
> Closed #135, Related To #133

## 변경 사항
> - domain: status 추가 (회원 탈퇴 여부)
> - dto: freeboard 리팩토링
> - controller: withdrawal 추가 및 freeboard 리팩토링
> - service: MemberService 탈퇴 로직 추가 및 freeboard 리팩토링, CustomUserDetailsService 예외 처리 로직 추가
> - repository: 회원 탈퇴 여부 검사

## 기타
> CurrentUserProvider repository의 JPA 메서드 이름이 바뀜에 따라 그 부분 이름만 변경했습니다.