### PR TITLE
Feat: 각 카테고리별 게시판에 해당되는 공지사항 최신순 5개만 볼 수 있도록 구현

### DIFF
--- a/src/main/java/com/example/fashionlog/controller/DailyLookController.java
+++ b/src/main/java/com/example/fashionlog/controller/DailyLookController.java
@@ -33,7 +33,7 @@ public class DailyLookController {
 
     @GetMapping
     public String getAllDailyLookPost(Model model) {
-        List<NoticeDto> noticeDto = noticeService.getNoticeListByDailyLook(Category.DAILY_LOOK)
+        List<NoticeDto> noticeDto = noticeService.getNoticeListByCategory(Category.DAILY_LOOK)
             .orElse(Collections.emptyList());
         model.addAttribute("dailylooks", dailyLookService.getAllDailyLookPost());
         model.addAttribute("dailyLookNotice", noticeDto);

--- a/src/main/java/com/example/fashionlog/controller/DailyLookController.java
+++ b/src/main/java/com/example/fashionlog/controller/DailyLookController.java
@@ -1,9 +1,14 @@
 package com.example.fashionlog.controller;
 
+import com.example.fashionlog.domain.Category;
 import com.example.fashionlog.dto.DailyLookCommentDto;
 import com.example.fashionlog.dto.DailyLookDto;
+import com.example.fashionlog.dto.NoticeDto;
 import com.example.fashionlog.service.DailyLookService;
 
+import com.example.fashionlog.service.NoticeService;
+import java.util.Collections;
+import java.util.List;
 import org.springframework.stereotype.Controller;
 
 import org.springframework.ui.Model;
@@ -19,14 +24,19 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class DailyLookController {
 
     private final DailyLookService dailyLookService;
+    private final NoticeService noticeService;
 
-    public DailyLookController(DailyLookService dailyLookService) {
+    public DailyLookController(DailyLookService dailyLookService, NoticeService noticeService) {
         this.dailyLookService = dailyLookService;
+        this.noticeService = noticeService;
     }
 
     @GetMapping
     public String getAllDailyLookPost(Model model) {
+        List<NoticeDto> noticeDto = noticeService.getNoticeListByDailyLook(Category.DAILY_LOOK)
+            .orElse(Collections.emptyList());
         model.addAttribute("dailylooks", dailyLookService.getAllDailyLookPost());
+        model.addAttribute("dailyLookNotice", noticeDto);
         return "dailylook/list";
     }
 

--- a/src/main/java/com/example/fashionlog/controller/FreeBoardController.java
+++ b/src/main/java/com/example/fashionlog/controller/FreeBoardController.java
@@ -43,7 +43,7 @@ public class FreeBoardController {
 		try {
 			List<FreeBoardDto> freeBoardDto = freeBoardService.getAllFreeBoards()
 				.orElse(Collections.emptyList());
-			List<NoticeDto> noticeDto = noticeService.getNoticeListByDailyLook(Category.FREE)
+			List<NoticeDto> noticeDto = noticeService.getNoticeListByCategory(Category.FREE)
 				.orElse(Collections.emptyList());
 			model.addAttribute("freeboards", freeBoardDto);
 			model.addAttribute("freeNotice", noticeDto);

--- a/src/main/java/com/example/fashionlog/controller/FreeBoardController.java
+++ b/src/main/java/com/example/fashionlog/controller/FreeBoardController.java
@@ -1,8 +1,11 @@
 package com.example.fashionlog.controller;
 
+import com.example.fashionlog.domain.Category;
 import com.example.fashionlog.dto.FreeBoardCommentDto;
 import com.example.fashionlog.dto.FreeBoardDto;
+import com.example.fashionlog.dto.NoticeDto;
 import com.example.fashionlog.service.FreeBoardService;
+import com.example.fashionlog.service.NoticeService;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class FreeBoardController {
 
 	private final FreeBoardService freeBoardService;
+	private final NoticeService noticeService;
 
 	/**
 	 * 자유 게시판 글 목록 조회
@@ -39,7 +43,10 @@ public class FreeBoardController {
 		try {
 			List<FreeBoardDto> freeBoardDto = freeBoardService.getAllFreeBoards()
 				.orElse(Collections.emptyList());
+			List<NoticeDto> noticeDto = noticeService.getNoticeListByDailyLook(Category.FREE)
+				.orElse(Collections.emptyList());
 			model.addAttribute("freeboards", freeBoardDto);
+			model.addAttribute("freeNotice", noticeDto);
 			return "freeboard/list";
 		} catch (SecurityException e) {
 			return "home";

--- a/src/main/java/com/example/fashionlog/controller/InterviewBoardController.java
+++ b/src/main/java/com/example/fashionlog/controller/InterviewBoardController.java
@@ -1,10 +1,15 @@
 package com.example.fashionlog.controller;
 
+import com.example.fashionlog.domain.Category;
 import com.example.fashionlog.domain.InterviewBoard;
 import com.example.fashionlog.dto.InterviewBoardCommentDto;
 import com.example.fashionlog.dto.InterviewBoardDto;
+import com.example.fashionlog.dto.NoticeDto;
 import com.example.fashionlog.service.InterviewBoardService;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.example.fashionlog.service.NoticeService;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,20 +18,20 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+@RequiredArgsConstructor
 @Controller
 @RequestMapping("/fashionlog/interviewboard")
 public class InterviewBoardController {
 
 	private final InterviewBoardService interviewBoardService;
-
-	@Autowired
-	public InterviewBoardController(InterviewBoardService interviewBoardService) {
-		this.interviewBoardService = interviewBoardService;
-	}
+	private final NoticeService noticeService;
 
 	@GetMapping
 	public String getAllInterviewBoards(Model model) {
+		List<NoticeDto> noticeDto = noticeService.getNoticeListByDailyLook(Category.INTERVIEW)
+			.orElse(Collections.emptyList());
 		model.addAttribute("interviewBoards", interviewBoardService.getAllInterviewPosts());
+		model.addAttribute("interviewNotice", noticeDto);
 		return "interviewboard/list";
 	}
 

--- a/src/main/java/com/example/fashionlog/controller/InterviewBoardController.java
+++ b/src/main/java/com/example/fashionlog/controller/InterviewBoardController.java
@@ -28,7 +28,7 @@ public class InterviewBoardController {
 
 	@GetMapping
 	public String getAllInterviewBoards(Model model) {
-		List<NoticeDto> noticeDto = noticeService.getNoticeListByDailyLook(Category.INTERVIEW)
+		List<NoticeDto> noticeDto = noticeService.getNoticeListByCategory(Category.INTERVIEW)
 			.orElse(Collections.emptyList());
 		model.addAttribute("interviewBoards", interviewBoardService.getAllInterviewPosts());
 		model.addAttribute("interviewNotice", noticeDto);

--- a/src/main/java/com/example/fashionlog/controller/LookbookController.java
+++ b/src/main/java/com/example/fashionlog/controller/LookbookController.java
@@ -41,7 +41,7 @@ public class LookbookController {
 	public String getAllLookbookList(Model model) {
 		List<LookbookDto> lookbookDto = lookbookService.getAllLookbooks()
 			.orElse(Collections.emptyList());
-		List<NoticeDto> noticeDto = noticeService.getNoticeListByDailyLook(Category.LOOKBOOK)
+		List<NoticeDto> noticeDto = noticeService.getNoticeListByCategory(Category.LOOKBOOK)
 			.orElse(Collections.emptyList());
 		model.addAttribute("lookbooks", lookbookDto);
 		model.addAttribute("lookbookNotice", noticeDto);

--- a/src/main/java/com/example/fashionlog/controller/LookbookController.java
+++ b/src/main/java/com/example/fashionlog/controller/LookbookController.java
@@ -1,12 +1,14 @@
 package com.example.fashionlog.controller;
 
+import com.example.fashionlog.domain.Category;
 import com.example.fashionlog.dto.LookbookCommentDto;
 import com.example.fashionlog.dto.LookbookDto;
+import com.example.fashionlog.dto.NoticeDto;
 import com.example.fashionlog.service.LookbookService;
+import com.example.fashionlog.service.NoticeService;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -15,17 +17,18 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequestMapping("/fashionlog/lookbook")
 public class LookbookController {
 
 	private final LookbookService lookbookService;
+	private final NoticeService noticeService;
 
 	@Autowired
-	public LookbookController(LookbookService lookbookService) {
+	public LookbookController(LookbookService lookbookService, NoticeService noticeService) {
 		this.lookbookService = lookbookService;
+		this.noticeService = noticeService;
 	}
 
 	/**
@@ -38,7 +41,10 @@ public class LookbookController {
 	public String getAllLookbookList(Model model) {
 		List<LookbookDto> lookbookDto = lookbookService.getAllLookbooks()
 			.orElse(Collections.emptyList());
+		List<NoticeDto> noticeDto = noticeService.getNoticeListByDailyLook(Category.LOOKBOOK)
+			.orElse(Collections.emptyList());
 		model.addAttribute("lookbooks", lookbookDto);
+		model.addAttribute("lookbookNotice", noticeDto);
 		return "lookbook/list";
 	}
 

--- a/src/main/java/com/example/fashionlog/controller/TradeController.java
+++ b/src/main/java/com/example/fashionlog/controller/TradeController.java
@@ -40,7 +40,7 @@ public class TradeController {
 	public String getAllTradeList(Model model) {
 		List<TradeDto> tradeDto = tradeService.getAllTrades()
 			.orElse(Collections.emptyList());
-		List<NoticeDto> noticeDto = noticeService.getNoticeListByDailyLook(Category.TRADE)
+		List<NoticeDto> noticeDto = noticeService.getNoticeListByCategory(Category.TRADE)
 			.orElse(Collections.emptyList());
 		model.addAttribute("trades", tradeDto);
 		model.addAttribute("tradeNotice", noticeDto);

--- a/src/main/java/com/example/fashionlog/controller/TradeController.java
+++ b/src/main/java/com/example/fashionlog/controller/TradeController.java
@@ -1,8 +1,10 @@
 package com.example.fashionlog.controller;
 
-import com.example.fashionlog.dto.LookbookCommentDto;
+import com.example.fashionlog.domain.Category;
+import com.example.fashionlog.dto.NoticeDto;
 import com.example.fashionlog.dto.TradeCommentDto;
 import com.example.fashionlog.dto.TradeDto;
+import com.example.fashionlog.service.NoticeService;
 import com.example.fashionlog.service.TradeService;
 import java.util.Collections;
 import java.util.List;
@@ -21,10 +23,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class TradeController {
 
 	private final TradeService tradeService;
+	private final NoticeService noticeService;
 
 	@Autowired
-	public TradeController(TradeService tradeService) {
+	public TradeController(TradeService tradeService, NoticeService noticeService) {
 		this.tradeService = tradeService;
+		this.noticeService = noticeService;
 	}
 
 	/**
@@ -36,7 +40,10 @@ public class TradeController {
 	public String getAllTradeList(Model model) {
 		List<TradeDto> tradeDto = tradeService.getAllTrades()
 			.orElse(Collections.emptyList());
+		List<NoticeDto> noticeDto = noticeService.getNoticeListByDailyLook(Category.TRADE)
+			.orElse(Collections.emptyList());
 		model.addAttribute("trades", tradeDto);
+		model.addAttribute("tradeNotice", noticeDto);
 		return "trade/list";
 	}
 

--- a/src/main/java/com/example/fashionlog/repository/NoticeRepository.java
+++ b/src/main/java/com/example/fashionlog/repository/NoticeRepository.java
@@ -1,5 +1,6 @@
 package com.example.fashionlog.repository;
 
+import com.example.fashionlog.domain.Category;
 import com.example.fashionlog.domain.Notice;
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +11,6 @@ public interface NoticeRepository extends JpaRepository<Notice,Long> {
 	List<Notice> findAllByStatusIsTrueOrderByCreatedAtDesc();
 
 	Optional<Notice> findByIdAndStatusIsTrue(Long id);
+
+	List<Notice> findTop5ByCategoryAndStatusIsTrueOrderByCreatedAtDesc(Category category);
 }

--- a/src/main/java/com/example/fashionlog/service/NoticeService.java
+++ b/src/main/java/com/example/fashionlog/service/NoticeService.java
@@ -92,7 +92,7 @@ public class NoticeService {
 		noticeComment.deleteComment();
 	}
 
-	public Optional<List<NoticeDto>> getNoticeListByDailyLook(Category category) {
+	public Optional<List<NoticeDto>> getNoticeListByCategory(Category category) {
 		System.out.println(category);
 		List<NoticeDto> getNotice = noticeRepository.findTop5ByCategoryAndStatusIsTrueOrderByCreatedAtDesc(category)
 			.stream()

--- a/src/main/java/com/example/fashionlog/service/NoticeService.java
+++ b/src/main/java/com/example/fashionlog/service/NoticeService.java
@@ -1,5 +1,6 @@
 package com.example.fashionlog.service;
 
+import com.example.fashionlog.domain.Category;
 import com.example.fashionlog.domain.Member;
 import com.example.fashionlog.domain.Notice;
 import com.example.fashionlog.domain.NoticeComment;
@@ -89,6 +90,16 @@ public class NoticeService {
 	public void deleteNoticeComment(Long commentId) {
 		NoticeComment noticeComment = findByIdAndCommentStatusIsTrue(commentId);
 		noticeComment.deleteComment();
+	}
+
+	public Optional<List<NoticeDto>> getNoticeListByDailyLook(Category category) {
+		System.out.println(category);
+		List<NoticeDto> getNotice = noticeRepository.findTop5ByCategoryAndStatusIsTrueOrderByCreatedAtDesc(category)
+			.stream()
+			.map(NoticeDto::convertToDto)
+			.collect(Collectors.toList());
+		System.out.println(getNotice);
+		return getNotice.isEmpty() ? Optional.empty() : Optional.of(getNotice);
 	}
 
 	private Notice findByIdAndStatusIsTrue(Long id) {

--- a/src/main/resources/static/css/board/list.css
+++ b/src/main/resources/static/css/board/list.css
@@ -67,3 +67,59 @@ th {
   background-color: #2980b9;
   text-decoration: none;
 }
+
+/* 공지사항 스타일 */
+.notice-item {
+  background-color: #f3d7db;
+}
+
+.notice-item:hover {
+  background-color: #ffeeba;
+}
+
+/* 인터뷰 게시물 스타일 */
+.interview-item {
+  background-color: #e6f3ff;
+}
+
+.interview-item:hover {
+  background-color: #d1e7ff;
+}
+
+/* 제목 열 스타일 */
+.post-item td:first-child {
+  font-weight: bold;
+}
+
+.post-item td:first-child a {
+  color: #333;
+  text-decoration: none;
+}
+
+.post-item td:first-child a:hover {
+  text-decoration: underline;
+}
+
+/* 분류 태그 스타일 */
+.category {
+  display: inline-block;
+  padding: 2px 5px;
+  margin-right: 10px;
+  font-size: 0.8em;
+  font-weight: normal;
+  color: #fff;
+  background-color: #f5526e;
+  border-radius: 3px;
+}
+
+/* 작성자와 작성일 스타일 */
+.post-item td:nth-child(2),
+.post-item td:last-child {
+  font-size: 0.9em;
+  color: #666;
+}
+
+/* 공통 스타일 오버라이드 */
+.post-item:hover {
+  background-color: inherit;
+}

--- a/src/main/resources/templates/dailylook/list.html
+++ b/src/main/resources/templates/dailylook/list.html
@@ -23,7 +23,17 @@
     </tr>
     </thead>
     <tbody>
-    <tr th:each="post:${dailylooks}" class="post-item">
+    <tr th:each="notice:${dailyLookNotice}" class="post-item notice-item">
+      <td>
+        <span class="category" th:text="${notice.category.getDisplayName()}">분류</span>
+        <a th:text="${notice.title}" th:href="@{/fashionlog/notice/{id}(id=${notice.id})}">제목</a>
+      </td>
+      <td>작성자</td>
+      <!-- updateAt이 null 이 아니면 updateAt 표시 -->
+      <td th:if="${notice.updatedAt != null}" th:text="${notice.updatedAt}">작성일</td>
+      <td th:unless="${notice.updatedAt != null}" th:text="${notice.createdAt}">작성일</td>
+    </tr>
+    <tr th:each="post:${dailylooks}" class="post-item interview-item">
       <td>
         <a th:text="${post.title}" th:href="@{/fashionlog/dailylook/{id}(id=${post.id})}">제목</a>
       </td>

--- a/src/main/resources/templates/freeboard/list.html
+++ b/src/main/resources/templates/freeboard/list.html
@@ -23,7 +23,17 @@
     </tr>
     </thead>
     <tbody>
-    <tr th:each="post:${freeboards}" class="post-item">
+    <tr th:each="notice:${freeNotice}" class="post-item notice-item">
+      <td>
+        <span class="category" th:text="${notice.category.getDisplayName()}">분류</span>
+        <a th:text="${notice.title}" th:href="@{/fashionlog/notice/{id}(id=${notice.id})}">제목</a>
+      </td>
+      <td>작성자</td>
+      <!-- updateAt이 null 이 아니면 updateAt 표시 -->
+      <td th:if="${notice.updatedAt != null}" th:text="${notice.updatedAt}">작성일</td>
+      <td th:unless="${notice.updatedAt != null}" th:text="${notice.createdAt}">작성일</td>
+    </tr>
+    <tr th:each="post:${freeboards}" class="post-item interview-item">
       <td>
         <a th:text="${post.title}" th:href="@{/fashionlog/freeboard/{id}(id=${post.id})}">제목</a>
       </td>

--- a/src/main/resources/templates/interviewboard/list.html
+++ b/src/main/resources/templates/interviewboard/list.html
@@ -23,7 +23,17 @@
     </tr>
     </thead>
     <tbody>
-    <tr th:each="interview:${interviewBoards}" class="post-item">
+    <tr th:each="notice:${interviewNotice}" class="post-item notice-item">
+      <td>
+        <span class="category" th:text="${notice.category.getDisplayName()}">분류</span>
+        <a th:text="${notice.title}" th:href="@{/fashionlog/notice/{id}(id=${notice.id})}">제목</a>
+      </td>
+      <td>작성자</td>
+      <!-- updateAt이 null 이 아니면 updateAt 표시 -->
+      <td th:if="${notice.updatedAt != null}" th:text="${notice.updatedAt}">작성일</td>
+      <td th:unless="${notice.updatedAt != null}" th:text="${notice.createdAt}">작성일</td>
+    </tr>
+    <tr th:each="interview:${interviewBoards}" class="post-item interview-item">
       <td>
         <a th:text="${interview.title}" th:href="@{/fashionlog/interviewboard/{id}(id=${interview.id})}">제목</a>
       </td>

--- a/src/main/resources/templates/lookbook/list.html
+++ b/src/main/resources/templates/lookbook/list.html
@@ -23,7 +23,17 @@
     </tr>
     </thead>
     <tbody>
-    <tr th:each="post:${lookbooks}" class="post-item">
+    <tr th:each="notice:${lookbookNotice}" class="post-item notice-item">
+      <td>
+        <span class="category" th:text="${notice.category.getDisplayName()}">분류</span>
+        <a th:text="${notice.title}" th:href="@{/fashionlog/notice/{id}(id=${notice.id})}">제목</a>
+      </td>
+      <td>작성자</td>
+      <!-- updateAt이 null 이 아니면 updateAt 표시 -->
+      <td th:if="${notice.updatedAt != null}" th:text="${notice.updatedAt}">작성일</td>
+      <td th:unless="${notice.updatedAt != null}" th:text="${notice.createdAt}">작성일</td>
+    </tr>
+    <tr th:each="post:${lookbooks}" class="post-item interview-item">
       <td>
         <a th:text="${post.title}" th:href="@{/fashionlog/lookbook/{id}(id=${post.id})}">제목</a>
       </td>

--- a/src/main/resources/templates/trade/list.html
+++ b/src/main/resources/templates/trade/list.html
@@ -34,7 +34,17 @@
     </tr>
     </thead>
     <tbody>
-    <tr th:each="post:${trades}" class="post-item">
+    <tr th:each="notice:${tradeNotice}" class="post-item notice-item">
+      <td>
+        <span class="category" th:text="${notice.category.getDisplayName()}">분류</span>
+        <a th:text="${notice.title}" th:href="@{/fashionlog/notice/{id}(id=${notice.id})}">제목</a>
+      </td>
+      <td>작성자</td>
+      <!-- updateAt이 null 이 아니면 updateAt 표시 -->
+      <td th:if="${notice.updatedAt != null}" th:text="${notice.updatedAt}">작성일</td>
+      <td th:unless="${notice.updatedAt != null}" th:text="${notice.createdAt}">작성일</td>
+    </tr>
+    <tr th:each="post:${trades}" class="post-item interview-item">
       <td>
         <a th:text="${post.title}" th:href="@{/fashionlog/trade/{id}(id=${post.id})}">제목</a>
       </td>


### PR DESCRIPTION
## 요약
> 각 카테고리별 게시판에 해당되는 공지사항 최신순 5개만 볼 수 있도록 구현

## 관련 이슈
> closed #126 

## 변경 사항
> - NoticeRepository & NoticeService
> 각 카테고리에 해당하는 공지사항을 최신순 5개를 받아오는 로직 추가
> - 카테고리 별 게시판 controller&ist.html
> 카테고리에 해당되는 공지사항 호출 로직 추가
> - 공지사항과 게시판 게시글을 구분할 수 있도록 css 추가

## 기타
> - 게시판과 겹치는 공지사항 css 파일들은 추후 리팩토링 시 삭제하도록 하겠습니다.
> - 현재 공지사항 게시판에서는 카테고리 상관없이 최신순 정렬로만 되어있는 상태인데요, category가 All인 공지글을 상단에 최신순 5개로 띄우면 어떨까요? 의견 주시면 감사하겠습니다!